### PR TITLE
hotfix: responsive keypads, Capital fixes, and French UI updates for beta.3

### DIFF
--- a/components/game/CapitalKeypad.tsx
+++ b/components/game/CapitalKeypad.tsx
@@ -34,40 +34,40 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ onDartInput, onUnd
   ];
 
   return (
-    <div className="flex h-full flex-col gap-2 border-t border-gray-800 bg-gray-950 p-2 shadow-2xl">
+    <div className="flex h-full min-h-0 flex-col gap-1.5 border-t border-gray-800 bg-gray-950 p-1.5 shadow-2xl sm:gap-2 sm:p-2">
       {/* Multiplier Toggles */}
-      <div className="flex h-12 gap-2">
+      <div className="grid h-10 shrink-0 grid-cols-3 gap-1.5 sm:h-12 sm:gap-2">
         <Button 
           variant={multiplier === 1 ? 'primary' : 'secondary'}
           onClick={() => setMultiplier(1)}
-          className={`flex-1 text-sm font-bold sm:text-lg ${multiplier === 1 ? 'bg-white text-black' : 'bg-gray-800 text-gray-400'}`}
+          className={`min-h-0 px-2 py-1 text-xs font-bold sm:text-lg ${multiplier === 1 ? 'bg-white text-black' : 'bg-gray-800 text-gray-400'}`}
         >
           SINGLE
         </Button>
         <Button 
           variant={multiplier === 2 ? 'primary' : 'secondary'}
           onClick={() => setMultiplier(2)}
-          className={`flex-1 text-sm font-bold sm:text-lg ${multiplier === 2 ? 'bg-cyan-500 text-black' : 'bg-gray-800 text-cyan-500'}`}
+          className={`min-h-0 px-2 py-1 text-xs font-bold sm:text-lg ${multiplier === 2 ? 'bg-cyan-500 text-black' : 'bg-gray-800 text-cyan-500'}`}
         >
           DOUBLE
         </Button>
         <Button 
           variant={multiplier === 3 ? 'primary' : 'secondary'}
           onClick={() => setMultiplier(3)}
-          className={`flex-1 text-sm font-bold sm:text-lg ${multiplier === 3 ? 'bg-orange-500 text-black' : 'bg-gray-800 text-orange-500'}`}
+          className={`min-h-0 px-2 py-1 text-xs font-bold sm:text-lg ${multiplier === 3 ? 'bg-orange-500 text-black' : 'bg-gray-800 text-orange-500'}`}
         >
           TRIPLE
         </Button>
       </div>
 
       {/* Numbers Grid */}
-      <div className="flex-1 grid grid-cols-5 gap-1">
+      <div className="grid min-h-0 flex-1 grid-cols-5 grid-rows-4 gap-1">
         {numbers.map(num => (
           <Button
             key={num}
             onClick={() => handleHit(num)}
             className={`
-              min-h-10 text-base font-black border-b-4 active:border-b-0 active:translate-y-1 transition-all sm:min-h-12 sm:text-xl
+              h-full min-h-0 px-1 py-1 text-sm font-black border-b-2 active:border-b-0 active:translate-y-0.5 transition-all sm:text-xl
               ${multiplier === 1 ? 'bg-gray-800 hover:bg-gray-700 text-white border-gray-900' : ''}
               ${multiplier === 2 ? 'bg-cyan-900/50 hover:bg-cyan-800 text-cyan-400 border-cyan-900' : ''}
               ${multiplier === 3 ? 'bg-orange-900/50 hover:bg-orange-800 text-orange-400 border-orange-900' : ''}
@@ -79,11 +79,11 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ onDartInput, onUnd
       </div>
 
       {/* Bottom Row: Bull, Miss, Undo */}
-      <div className="grid h-14 grid-cols-4 gap-2">
+      <div className="grid h-11 shrink-0 grid-cols-4 gap-1.5 sm:h-14 sm:gap-2">
         <Button 
           onClick={() => handleHit(25)}
           className={`
-            col-span-2 text-sm font-black border-b-4 active:border-b-0 active:translate-y-1 transition-all sm:text-xl
+            col-span-2 min-h-0 px-2 py-1 text-xs font-black border-b-2 active:border-b-0 active:translate-y-0.5 transition-all sm:text-xl
             ${multiplier === 2 ? 'bg-red-600 hover:bg-red-500 text-white border-red-800' : 'bg-green-700 hover:bg-green-600 text-white border-green-900'}
           `}
         >
@@ -92,7 +92,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ onDartInput, onUnd
         <Button 
           variant="danger" 
           onClick={handleMiss} 
-          className="text-sm font-bold sm:text-lg"
+          className="min-h-0 px-2 py-1 text-xs font-bold sm:text-lg"
         >
           MISS
         </Button>
@@ -100,7 +100,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ onDartInput, onUnd
           variant="secondary" 
           onClick={onUndo} 
           disabled={!canUndo} 
-          className="text-xs font-bold text-gray-400 sm:text-sm"
+          className="min-h-0 px-2 py-1 text-[10px] font-bold text-gray-400 sm:text-sm"
         >
           UNDO
         </Button>

--- a/components/game/CricketKeypad.tsx
+++ b/components/game/CricketKeypad.tsx
@@ -11,20 +11,16 @@ interface CricketKeypadProps {
 }
 
 export const CricketKeypad: React.FC<CricketKeypadProps> = ({ onHit, onMiss, onUndo, canUndo }) => {
-    
-    // Optimization: Layout designed to fill bottom 45% of screen perfectly
-    // Grouped by row for easier thumb reach
-    
     return (
-        <div className="flex h-full flex-col gap-1 border-t border-gray-800 bg-gray-950 p-1 shadow-2xl">
+        <div className="flex h-full min-h-0 flex-col gap-1.5 border-t border-gray-800 bg-gray-950 p-1.5 shadow-2xl sm:gap-2 sm:p-2">
             
             {/* Top Row: 20, 19, 18 - Most frequent */}
-            <div className="flex-1 grid grid-cols-3 gap-1">
+            <div className="grid min-h-0 flex-1 grid-cols-3 gap-1 sm:gap-2">
                 {[20, 19, 18].map(num => (
                     <Button 
                         key={num}
                         onClick={() => onHit(num as CricketTarget, 1)}
-                        className="min-h-14 text-2xl font-black bg-gray-800 text-white border-b-4 border-gray-900 transition-all active:translate-y-1 active:border-b-0 hover:bg-gray-700 sm:text-4xl"
+                        className="h-full min-h-0 px-1 py-1 text-xl font-black bg-gray-800 text-white border-b-2 border-gray-900 transition-all active:translate-y-0.5 active:border-b-0 hover:bg-gray-700 sm:text-4xl"
                     >
                         {num}
                     </Button>
@@ -32,12 +28,12 @@ export const CricketKeypad: React.FC<CricketKeypadProps> = ({ onHit, onMiss, onU
             </div>
 
             {/* Second Row: 17, 16, 15 */}
-            <div className="flex-1 grid grid-cols-3 gap-1">
+            <div className="grid min-h-0 flex-1 grid-cols-3 gap-1 sm:gap-2">
                  {[17, 16, 15].map(num => (
                     <Button 
                         key={num}
                         onClick={() => onHit(num as CricketTarget, 1)}
-                        className="min-h-14 text-2xl font-black bg-gray-800 text-white border-b-4 border-gray-900 transition-all active:translate-y-1 active:border-b-0 hover:bg-gray-700 sm:text-4xl"
+                        className="h-full min-h-0 px-1 py-1 text-xl font-black bg-gray-800 text-white border-b-2 border-gray-900 transition-all active:translate-y-0.5 active:border-b-0 hover:bg-gray-700 sm:text-4xl"
                     >
                         {num}
                     </Button>
@@ -45,64 +41,68 @@ export const CricketKeypad: React.FC<CricketKeypadProps> = ({ onHit, onMiss, onU
             </div>
 
             {/* Special & Multipliers Row */}
-            <div className="grid h-14 grid-cols-4 gap-1 sm:h-16">
+            <div className="grid h-11 shrink-0 grid-cols-2 gap-1 sm:h-14 sm:grid-cols-4 sm:gap-2">
                 <Button 
                     onClick={() => onHit(25, 1)}
-                    className="text-sm font-black bg-red-900/30 text-red-500 border border-red-900/50 hover:bg-red-900/50 sm:text-xl"
+                    className="min-h-0 px-2 py-1 text-xs font-black bg-red-900/30 text-red-500 border border-red-900/50 hover:bg-red-900/50 sm:text-xl"
                 >
                     BULL
                 </Button>
                 <Button 
                     variant="secondary"
                     onClick={() => onHit(25, 2)}
-                    className="text-xs font-black bg-red-600 text-white shadow-[0_0_10px_rgba(220,38,38,0.4)] hover:bg-red-500 sm:text-lg"
+                    className="min-h-0 px-2 py-1 text-[10px] font-black bg-red-600 text-white shadow-[0_0_10px_rgba(220,38,38,0.4)] hover:bg-red-500 sm:text-lg"
                 >
                     D-BULL
                 </Button>
-                {/* Multiplier Toggles (Actually hit 20/19/etc with multiplier applied logic is complex without selection state)
-                    For simplicity in this keypad version, we create specific Multiplier MODES or just rows.
-                    Wait, previous logic was direct hit. 
-                    Let's adapt: We need to allow hitting D20, T20 etc. 
-                    
-                    BETTER MOBILE LAYOUT: 
-                    Left side: Numbers grid. 
-                    Right side: Multipliers (Double/Triple) acting as modifiers? No, that's slow.
-                    
-                    Let's stick to the grid but add dedicated Double/Triple strips below the numbers.
-                */}
+                <Button 
+                    variant="danger"
+                    onClick={onMiss}
+                    className="min-h-0 px-2 py-1 text-xs font-bold sm:text-lg"
+                >
+                    MISS
+                </Button>
+                <Button 
+                    variant="secondary"
+                    onClick={onUndo}
+                    disabled={!canUndo}
+                    className="min-h-0 px-2 py-1 text-[10px] font-bold text-gray-500 sm:text-sm"
+                >
+                    UNDO
+                </Button>
             </div>
-
-            {/* Modifiers / Action Row - REFACTORED FOR SPEED */}
-            {/* We need a way to hit T20 without 2 clicks if possible, OR make it easy. 
-                Given screen constraint, 2-click (Select Modifier -> Select Number) or standard grid is best.
-                Let's stick to the previous direct approach but optimized.
-            */}
             
-             <div className="flex-1 grid grid-cols-3 gap-1">
+             <div className="grid min-h-0 flex-[1.15] grid-cols-3 gap-1 sm:gap-2">
                 {/* Double Strip */}
-                <div className="grid grid-cols-1 gap-1">
-                     <Button variant="secondary" className="pointer-events-none flex-1 border-none bg-gray-900 text-[10px] font-bold text-cyan-400 sm:text-xs">DOUBLES</Button>
-                     <div className="grid grid-cols-3 gap-0.5">
+                <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+                     <Button variant="secondary" className="pointer-events-none min-h-0 border-none px-1 py-1 bg-gray-900 text-[10px] font-bold text-cyan-400 sm:text-xs">DOUBLES</Button>
+                     <div className="grid min-h-0 grid-cols-3 grid-rows-2 gap-0.5 sm:gap-1">
                         {[20,19,18,17,16,15].map(n => (
-                            <button key={`d${n}`} onClick={() => onHit(n as CricketTarget, 2)} className="h-8 rounded border border-gray-700 bg-gray-800 text-xs font-bold text-cyan-400 sm:text-sm">{n}</button>
+                            <button key={`d${n}`} onClick={() => onHit(n as CricketTarget, 2)} className="h-full min-h-0 rounded border border-gray-700 bg-gray-800 px-1 py-1 text-[10px] font-bold text-cyan-400 transition-colors hover:bg-cyan-900/40 sm:text-sm">{n}</button>
                         ))}
                      </div>
                 </div>
 
                 {/* Triple Strip */}
-                <div className="grid grid-cols-1 gap-1">
-                     <Button variant="secondary" className="pointer-events-none flex-1 border-none bg-gray-900 text-[10px] font-bold text-orange-400 sm:text-xs">TRIPLES</Button>
-                     <div className="grid grid-cols-3 gap-0.5">
+                <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+                     <Button variant="secondary" className="pointer-events-none min-h-0 border-none px-1 py-1 bg-gray-900 text-[10px] font-bold text-orange-400 sm:text-xs">TRIPLES</Button>
+                     <div className="grid min-h-0 grid-cols-3 grid-rows-2 gap-0.5 sm:gap-1">
                         {[20,19,18,17,16,15].map(n => (
-                            <button key={`t${n}`} onClick={() => onHit(n as CricketTarget, 3)} className="h-8 rounded border border-gray-700 bg-gray-800 text-xs font-bold text-orange-400 sm:text-sm">{n}</button>
+                            <button key={`t${n}`} onClick={() => onHit(n as CricketTarget, 3)} className="h-full min-h-0 rounded border border-gray-700 bg-gray-800 px-1 py-1 text-[10px] font-bold text-orange-400 transition-colors hover:bg-orange-900/40 sm:text-sm">{n}</button>
                         ))}
                      </div>
                 </div>
 
-                 {/* Actions */}
-                 <div className="flex flex-col gap-1">
-                    <Button variant="danger" onClick={onMiss} className="flex-1 text-base font-bold sm:text-xl">MISS</Button>
-                    <Button variant="secondary" onClick={onUndo} disabled={!canUndo} className="h-10 text-xs font-bold text-gray-500 sm:text-sm">UNDO</Button>
+                 {/* Singles reminder / quick lane */}
+                 <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+                    <Button variant="secondary" className="pointer-events-none min-h-0 border-none px-1 py-1 bg-gray-900 text-[10px] font-bold text-white/70 sm:text-xs">SINGLES</Button>
+                    <div className="grid min-h-0 grid-cols-2 grid-rows-3 gap-0.5 sm:gap-1">
+                        {[20, 19, 18, 17, 16, 15].map(n => (
+                            <button key={`s${n}`} onClick={() => onHit(n as CricketTarget, 1)} className="h-full min-h-0 rounded border border-gray-700 bg-gray-800 px-1 py-1 text-xs font-bold text-white transition-colors hover:bg-gray-700 sm:text-sm">
+                                {n}
+                            </button>
+                        ))}
+                    </div>
                  </div>
             </div>
         </div>

--- a/components/game/Keypad.tsx
+++ b/components/game/Keypad.tsx
@@ -37,7 +37,7 @@ export const Keypad: React.FC<KeypadProps> = ({
                   key={`L-${idx}`} 
                   variant="secondary" 
                   onClick={() => onQuickAction && onQuickAction(val)}
-                  className="h-full min-h-10 text-base font-black bg-gray-900/80 border-gray-800 text-cyan-500 hover:text-white hover:bg-cyan-900 hover:border-cyan-500/50 shadow-lg transition-all sm:min-h-11 md:min-h-12 lg:text-xl"
+                  className="h-full min-h-0 px-1 py-1 text-sm font-black bg-gray-900/80 border-gray-800 text-cyan-500 hover:text-white hover:bg-cyan-900 hover:border-cyan-500/50 shadow-lg transition-all sm:text-base lg:text-xl"
                >
                   {val}
                </Button>
@@ -53,16 +53,16 @@ export const Keypad: React.FC<KeypadProps> = ({
                   key={k} 
                   variant="secondary" 
                   onClick={() => onInput(k)}
-                  className="h-full min-h-10 text-lg font-bold bg-gray-800 hover:bg-gray-700 border-gray-700 shadow-inner active:scale-95 transition-transform sm:min-h-11 sm:text-xl md:min-h-12 md:text-2xl"
+                  className="h-full min-h-0 px-1 py-1 text-base font-bold bg-gray-800 hover:bg-gray-700 border-gray-700 shadow-inner active:scale-95 transition-transform sm:text-xl md:text-2xl"
                 >
                   {k}
                 </Button>
               ))}
           </div>
           <div className="grid grid-cols-3 gap-1.5 sm:gap-2">
-              <Button variant="danger" onClick={onClear} className="h-full min-h-10 text-sm font-bold shadow-sm sm:min-h-11 sm:text-base md:min-h-12 md:text-lg">C</Button>
-              <Button variant="secondary" onClick={() => onInput(0)} className="h-full min-h-10 text-lg font-bold bg-gray-800 border-gray-700 shadow-inner sm:min-h-11 sm:text-xl md:min-h-12 md:text-2xl">0</Button>
-              <Button variant="secondary" onClick={onEnter} className="h-full min-h-10 text-sm font-black bg-gray-800 border-gray-700 shadow-inner sm:min-h-11 sm:text-base md:min-h-12 md:text-lg">OK</Button>
+              <Button variant="danger" onClick={onClear} className="h-full min-h-0 px-1 py-1 text-xs font-bold shadow-sm sm:text-base md:text-lg">C</Button>
+              <Button variant="secondary" onClick={() => onInput(0)} className="h-full min-h-0 px-1 py-1 text-base font-bold bg-gray-800 border-gray-700 shadow-inner sm:text-xl md:text-2xl">0</Button>
+              <Button variant="secondary" onClick={onEnter} className="h-full min-h-0 px-1 py-1 text-xs font-black bg-gray-800 border-gray-700 shadow-inner sm:text-base md:text-lg">OK</Button>
           </div>
       </div>
 
@@ -74,7 +74,7 @@ export const Keypad: React.FC<KeypadProps> = ({
                   key={`R-${idx}`} 
                   variant="secondary" 
                   onClick={() => onQuickAction && onQuickAction(val)}
-                  className="h-full min-h-10 text-base font-black bg-gray-900/80 border-gray-800 text-orange-500 hover:text-white hover:bg-orange-900 hover:border-orange-500/50 shadow-lg transition-all sm:min-h-11 md:min-h-12 lg:text-xl"
+                  className="h-full min-h-0 px-1 py-1 text-sm font-black bg-gray-900/80 border-gray-800 text-orange-500 hover:text-white hover:bg-orange-900 hover:border-orange-500/50 shadow-lg transition-all sm:text-base lg:text-xl"
                >
                   {val}
                </Button>

--- a/components/lobby/LobbyHeader.tsx
+++ b/components/lobby/LobbyHeader.tsx
@@ -8,10 +8,10 @@ interface LobbyHeaderProps {
 
 export const LobbyHeader: React.FC<LobbyHeaderProps> = ({ profile, stats }) => {
   const summaryItems = [
-    { label: 'Average', value: stats.globalAverage.toFixed(1) },
+    { label: 'Moyenne', value: stats.globalAverage.toFixed(1) },
     { label: 'Checkout', value: `${stats.checkoutRate}%` },
-    { label: 'Wins', value: `${stats.totalWins}` },
-    { label: 'Last Result', value: profile.lastResult === 'win' ? 'Victory' : 'Defeat' },
+    { label: 'Victoires', value: `${stats.totalWins}` },
+    { label: 'Dernier Resultat', value: profile.lastResult === 'win' ? 'Victoire' : 'Defaite' },
   ];
 
   const progress = Math.min(100, Math.round((profile.xp / profile.xpToNextLevel) * 100));
@@ -21,7 +21,7 @@ export const LobbyHeader: React.FC<LobbyHeaderProps> = ({ profile, stats }) => {
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
         <div className="space-y-5">
           <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-            Active Lobby
+            Lobby Actif
           </div>
 
           <div className="flex items-center gap-4">
@@ -42,7 +42,7 @@ export const LobbyHeader: React.FC<LobbyHeaderProps> = ({ profile, stats }) => {
                 </h1>
               </div>
               <p className="mt-2 text-sm text-gray-400 sm:text-base">
-                Favorite mode: <span className="font-black text-white">{profile.favoriteMode}</span>
+                Mode favori : <span className="font-black text-white">{profile.favoriteMode}</span>
               </p>
             </div>
           </div>
@@ -60,7 +60,7 @@ export const LobbyHeader: React.FC<LobbyHeaderProps> = ({ profile, stats }) => {
         <div className="rounded-[1.75rem] border border-white/8 bg-black/20 p-5">
           <div className="mb-3 flex items-center justify-between">
             <p className="text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Progression</p>
-            <span className="text-sm font-black uppercase text-orange-300">Level {profile.level}</span>
+            <span className="text-sm font-black uppercase text-orange-300">Niveau {profile.level}</span>
           </div>
           <div className="mb-3 h-3 overflow-hidden rounded-full bg-white/10">
             <div
@@ -70,7 +70,7 @@ export const LobbyHeader: React.FC<LobbyHeaderProps> = ({ profile, stats }) => {
           </div>
           <div className="flex items-center justify-between text-sm text-gray-400">
             <span>{profile.xp} XP</span>
-            <span>{profile.xpToNextLevel} XP next rank</span>
+            <span>{profile.xpToNextLevel} XP vers le prochain rang</span>
           </div>
         </div>
       </div>

--- a/components/lobby/QuickActions.tsx
+++ b/components/lobby/QuickActions.tsx
@@ -22,17 +22,17 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
   onChallengeFriend,
 }) => {
   const actions: QuickAction[] = [
-    { label: 'Nouvelle Partie', description: 'Launch directly into arena setup', icon: <Play className="h-5 w-5" />, onClick: onNewGame },
-    { label: 'Reprendre', description: 'Continue your latest prepared flow', icon: <RefreshCw className="h-5 w-5" />, onClick: onResume },
-    { label: 'Rejoindre Avec Un Code', description: 'Join a private darts room quickly', icon: <UsersRound className="h-5 w-5" />, onClick: onJoinWithCode },
-    { label: 'Defier Un Ami', description: 'Start a direct competitive challenge', icon: <Swords className="h-5 w-5" />, onClick: onChallengeFriend },
+    { label: 'Nouvelle Partie', description: 'Lancer directement la configuration d\'arena', icon: <Play className="h-5 w-5" />, onClick: onNewGame },
+    { label: 'Reprendre', description: 'Continuer ton dernier parcours prepare', icon: <RefreshCw className="h-5 w-5" />, onClick: onResume },
+    { label: 'Rejoindre Avec Un Code', description: 'Rejoindre rapidement une salle privee', icon: <UsersRound className="h-5 w-5" />, onClick: onJoinWithCode },
+    { label: 'Defier Un Ami', description: 'Lancer un duel direct et competitif', icon: <Swords className="h-5 w-5" />, onClick: onChallengeFriend },
   ];
 
   return (
     <section className="rounded-[2rem] border border-white/10 bg-[#101722]/86 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.22)] backdrop-blur-xl sm:p-6">
       <div className="mb-4">
-        <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Quick Actions</p>
-        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Step To The Oche</h2>
+        <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Actions Rapides</p>
+        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">A Toi L'Oche</h2>
       </div>
 
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
@@ -48,7 +48,7 @@ export const QuickActions: React.FC<QuickActionsProps> = ({
             <div className="mb-2 text-sm font-black uppercase tracking-[0.16em] text-white">{action.label}</div>
             <div className="text-sm leading-6 text-gray-400">{action.description}</div>
             <div className="mt-4 inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-orange-300">
-              Open
+              Ouvrir
               <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
             </div>
           </button>

--- a/components/lobby/RecentMatches.tsx
+++ b/components/lobby/RecentMatches.tsx
@@ -9,14 +9,14 @@ export const RecentMatches: React.FC<RecentMatchesProps> = ({ matches }) => {
   return (
     <section className="rounded-[2rem] border border-white/10 bg-[#101722]/86 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.22)] backdrop-blur-xl sm:p-6">
       <div className="mb-5">
-        <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Recent History</p>
-        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Latest Matches</h2>
+        <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Historique Recent</p>
+        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Derniers Matchs</h2>
       </div>
 
       <div className="space-y-3">
         {matches.length === 0 ? (
           <div className="rounded-[1.4rem] border border-dashed border-white/10 bg-black/20 px-4 py-6 text-sm text-gray-400">
-            No tracked matches yet. Finish a saved game to populate your recent history.
+            Aucun match suivi pour le moment. Termine une partie sauvegardee pour alimenter ton historique recent.
           </div>
         ) : matches.map((match) => (
           <div key={match.id} className="rounded-[1.4rem] border border-white/8 bg-black/20 px-4 py-4">
@@ -32,7 +32,7 @@ export const RecentMatches: React.FC<RecentMatchesProps> = ({ matches }) => {
                     : 'border border-red-500/30 bg-red-500/10 text-red-300'
                 }`}
               >
-                {match.result}
+                {match.result === 'win' ? 'Victoire' : 'Defaite'}
               </span>
             </div>
             <div className="flex items-center justify-between text-sm">

--- a/components/lobby/SocialPanel.tsx
+++ b/components/lobby/SocialPanel.tsx
@@ -12,15 +12,15 @@ export const SocialPanel: React.FC<SocialPanelProps> = ({ friends, invites, join
     <section className="space-y-4 rounded-[2rem] border border-white/10 bg-[#101722]/86 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.22)] backdrop-blur-xl sm:p-6">
       <div>
         <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Social</p>
-        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Friends & Multiplayer</h2>
+        <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Amis Et Multijoueur</h2>
       </div>
 
       <div className="rounded-[1.5rem] border border-white/8 bg-black/20 p-4">
-        <div className="mb-3 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Friends Online</div>
+        <div className="mb-3 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Amis En Ligne</div>
         <div className="space-y-3">
           {friends.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-sm text-gray-400">
-              Friends syncing will appear here once social tables are connected.
+              Les amis synchronises apparaitront ici une fois les tables sociales connectees.
             </div>
           ) : friends.map((friend) => (
             <div key={friend.id} className="flex items-center gap-3">
@@ -50,7 +50,7 @@ export const SocialPanel: React.FC<SocialPanelProps> = ({ friends, invites, join
         <div className="space-y-3">
           {invites.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-sm text-gray-400">
-              No pending invites yet.
+              Aucune invitation en attente pour le moment.
             </div>
           ) : invites.map((invite) => (
             <div key={invite.id} className="flex items-center justify-between gap-3 rounded-2xl border border-white/8 bg-white/[0.03] px-3 py-3">
@@ -58,18 +58,18 @@ export const SocialPanel: React.FC<SocialPanelProps> = ({ friends, invites, join
                 <div className="text-sm font-black text-white">{invite.username}</div>
                 <div className="text-sm text-gray-400">{invite.mode} · {invite.createdAt}</div>
               </div>
-              <div className="text-[10px] font-black uppercase tracking-[0.16em] text-orange-300">{invite.type}</div>
+              <div className="text-[10px] font-black uppercase tracking-[0.16em] text-orange-300">{invite.type === 'incoming' ? 'Recue' : 'Envoyee'}</div>
             </div>
           ))}
         </div>
       </div>
 
       <div className="rounded-[1.5rem] border border-white/8 bg-black/20 p-4">
-        <div className="mb-3 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Joinable Lobbies</div>
+        <div className="mb-3 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Lobbies Rejoignables</div>
         <div className="space-y-3">
           {joinableLobbies.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-sm text-gray-400">
-              Open multiplayer lobbies will show up here when this feature goes live.
+              Les lobbies multijoueur ouverts apparaitront ici quand cette fonctionnalite sera active.
             </div>
           ) : joinableLobbies.map((lobby) => (
             <div key={lobby.id} className="rounded-2xl border border-white/8 bg-white/[0.03] px-3 py-3">

--- a/components/ui/ChangelogModal.tsx
+++ b/components/ui/ChangelogModal.tsx
@@ -71,7 +71,7 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = ({ onClose }) => {
                     <div>
                         <h4 className="text-green-500 text-xs font-bold uppercase tracking-widest mb-1">🚀 Améliorations</h4>
                         <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-green-500/50">
-                            <li>Refonte des écrans <b>Home</b>, <b>Login</b>, <b>Arena Setup</b>, <b>History</b>, <b>My Stats</b> et <b>My Account</b>.</li>
+                            <li>Refonte des écrans <b>Accueil</b>, <b>Connexion</b>, <b>Configuration Arena</b>, <b>Historique</b>, <b>Mes Stats</b> et <b>Mon Compte</b>.</li>
                             <li>Stockage Supabase enrichi pour les <b>stats de matchs</b>, les achievements et les challenges.</li>
                             <li>Optimisation du frontend avec <b>lazy-loading</b> et meilleur découpage du bundle.</li>
                         </ul>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -439,7 +439,7 @@ export const fetchLobbyFriends = async (userId: string) => {
       username: profile.username,
       avatarUrl: `https://api.dicebear.com/9.x/avataaars/svg?seed=${encodeURIComponent(profile.avatar_seed)}&backgroundColor=b6e3f4`,
       status: friendPresence?.availability === 'online' || friendPresence?.availability === 'in_match' ? friendPresence.availability : 'idle',
-      activity: friendPresence?.activity_text || 'Ready for the next throw',
+      activity: friendPresence?.activity_text || 'Pret pour la prochaine volee',
     };
   });
 };
@@ -497,7 +497,7 @@ export const fetchFriendRequests = async (userId: string) => {
 
 export const createFriendRequest = async (requesterUserId: string, addresseeUserId: string) => {
   if (!requesterUserId || !addresseeUserId || requesterUserId === addresseeUserId) {
-    return { data: null, error: { message: 'Invalid friend request.' } };
+    return { data: null, error: { message: 'Demande d\'ami invalide.' } };
   }
 
   const { data: existingRow, error: existingError } = await supabase
@@ -516,11 +516,11 @@ export const createFriendRequest = async (requesterUserId: string, addresseeUser
 
   if (existingRow) {
     if (existingRow.status === 'accepted') {
-      return { data: existingRow, error: { message: 'This player is already in your friends list.' } };
+      return { data: existingRow, error: { message: 'Ce joueur est deja dans ta liste d\'amis.' } };
     }
 
     if (existingRow.status === 'pending') {
-      return { data: existingRow, error: { message: 'A friend request is already pending.' } };
+      return { data: existingRow, error: { message: 'Une demande d\'ami est deja en attente.' } };
     }
   }
 
@@ -575,7 +575,7 @@ export const createEmailFriendInvite = async (senderUserId: string, recipientEma
   const normalizedEmail = recipientEmail.trim().toLowerCase();
 
   if (!senderUserId || !normalizedEmail) {
-    return { data: null, error: { message: 'Recipient email is required.' } };
+    return { data: null, error: { message: 'L\'email du destinataire est requis.' } };
   }
 
   const { data, error } = await supabase
@@ -717,7 +717,7 @@ export const fetchJoinableLobbies = async () => {
     id: row.id,
     host: profilesByUserId.get(row.host_user_id)?.username || 'host',
     mode: row.mode,
-    stakes: row.stakes || row.title || 'Open match',
+    stakes: row.stakes || row.title || 'Match ouvert',
     players: `${row.current_players} / ${row.max_players}`,
     lobbyCode: row.lobby_code,
     gameConfig: row.game_config || {},
@@ -726,7 +726,7 @@ export const fetchJoinableLobbies = async () => {
 
 export const findOpenLobbyByCode = async (code: string) => {
   const normalizedCode = code.trim().toUpperCase();
-  if (!normalizedCode) return { data: null, error: { message: 'Lobby code is required.' } };
+  if (!normalizedCode) return { data: null, error: { message: 'Le code du lobby est requis.' } };
 
   const { data: lobby, error } = await supabase
     .from('open_lobbies')
@@ -760,7 +760,7 @@ export const findOpenLobbyByCode = async (code: string) => {
       lobbyCode: lobby.lobby_code,
       mode: lobby.mode,
       title: lobby.title,
-      stakes: lobby.stakes || lobby.title || 'Open match',
+      stakes: lobby.stakes || lobby.title || 'Match ouvert',
       currentPlayers: lobby.current_players,
       maxPlayers: lobby.max_players,
       hostUserId: lobby.host_user_id,
@@ -810,8 +810,8 @@ export const createOpenLobby = async (
     .insert({
       host_user_id: hostUserId,
       mode: payload.mode,
-      title: payload.title.trim() || 'Open Match',
-      stakes: payload.stakes.trim() || 'Open match',
+      title: payload.title.trim() || 'Match Ouvert',
+      stakes: payload.stakes.trim() || 'Match ouvert',
       current_players: 1,
       max_players: payload.maxPlayers,
       status: 'open',
@@ -840,8 +840,8 @@ export const updateOpenLobby = async (
   const { data, error } = await supabase
     .from('open_lobbies')
     .update({
-      ...(payload.title !== undefined ? { title: payload.title.trim() || 'Open Match' } : {}),
-      ...(payload.stakes !== undefined ? { stakes: payload.stakes.trim() || 'Open match' } : {}),
+      ...(payload.title !== undefined ? { title: payload.title.trim() || 'Match Ouvert' } : {}),
+      ...(payload.stakes !== undefined ? { stakes: payload.stakes.trim() || 'Match ouvert' } : {}),
       ...(payload.maxPlayers !== undefined ? { max_players: payload.maxPlayers } : {}),
       ...(payload.status !== undefined ? { status: payload.status } : {}),
       ...(payload.gameConfig !== undefined ? { game_config: payload.gameConfig } : {}),
@@ -1052,7 +1052,7 @@ export const fetchOpenLobbyRoomByCode = async (code: string) => {
       lobbyCode: lobby.lobby_code,
       mode: lobby.mode,
       title: lobby.title,
-      stakes: lobby.stakes || lobby.title || 'Open match',
+      stakes: lobby.stakes || lobby.title || 'Match ouvert',
       currentPlayers: lobby.current_players,
       maxPlayers: lobby.max_players,
       status: lobby.status,
@@ -1152,8 +1152,8 @@ export const fetchResumableLobbyEntries = async (userId: string) => {
         id: lobby.id,
         lobbyCode: lobby.lobby_code,
         mode: lobby.mode,
-        title: lobby.title || 'Open Match',
-        stakes: lobby.stakes || lobby.title || 'Open match',
+        title: lobby.title || 'Match Ouvert',
+        stakes: lobby.stakes || lobby.title || 'Match ouvert',
         status: lobby.status as 'open' | 'locked' | 'in_progress' | 'closed',
         currentPlayers: lobby.current_players,
         maxPlayers: lobby.max_players,

--- a/src/lib/lobbyData.ts
+++ b/src/lib/lobbyData.ts
@@ -59,7 +59,7 @@ export async function fetchLobbyData(user: any): Promise<LobbyData> {
 
   void upsertPlayerPresence(user?.id, {
     availability: 'online',
-    activity_text: 'In lobby',
+    activity_text: 'Dans le lobby',
     current_mode: null,
   });
 
@@ -220,11 +220,11 @@ function getFavoriteMode(modeTotals: Record<LobbyGameMode, number>): LobbyGameMo
 }
 
 function getRankFromLevel(level: number) {
-  if (level >= 30) return 'Arena Master';
-  if (level >= 22) return 'Board Specialist';
-  if (level >= 15) return 'County Elite';
-  if (level >= 8) return 'League Contender';
-  return 'Practice Squad';
+  if (level >= 30) return 'Maitre de l\'Arena';
+  if (level >= 22) return 'Specialiste du Board';
+  if (level >= 15) return 'Elite Regionale';
+  if (level >= 8) return 'Pretendant de Ligue';
+  return 'Escouade d\'Entrainement';
 }
 
 function toRecentMatchItem(record: MatchRecord): MatchHistoryItem {
@@ -234,10 +234,10 @@ function toRecentMatchItem(record: MatchRecord): MatchHistoryItem {
   const opponentLabel =
     record.opponent_label ||
     (playerNames.length <= 1
-      ? 'Solo session'
+      ? 'Session solo'
       : playerNames.length === 2
         ? `vs ${playerNames[1]}`
-        : `${playerNames.length}-player table`);
+        : `Table de ${playerNames.length} joueurs`);
 
   const scoreLabel =
     typeof record.score_for === 'number' || typeof record.score_against === 'number'
@@ -270,9 +270,9 @@ function formatRelativeDate(value: string) {
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
   const diffDays = Math.floor(diffHours / 24);
 
-  if (diffHours < 1) return 'Just now';
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays === 1) return 'Yesterday';
+  if (diffHours < 1) return 'A l\'instant';
+  if (diffHours < 24) return `Il y a ${diffHours}h`;
+  if (diffDays === 1) return 'Hier';
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
@@ -280,32 +280,32 @@ function buildAchievements(stats: PlayerStats, totalMatches: number): Achievemen
   return [
     {
       id: 'highest-checkout',
-      title: 'High Checkout',
-      description: 'Push your best finish toward the iconic 170 ceiling.',
+      title: 'Gros Checkout',
+      description: 'Pousse ton meilleur finish vers le plafond mythique de 170.',
       progress: stats.bestCheckout,
       maxProgress: 170,
       unlocked: stats.bestCheckout >= 100,
     },
     {
       id: 'match-winner',
-      title: 'Match Winner',
-      description: 'Build your career wins across all registered matches.',
+      title: 'Gagne-Match',
+      description: 'Construis ton total de victoires sur tous les matchs enregistres.',
       progress: stats.totalWins,
       maxProgress: 50,
       unlocked: stats.totalWins >= 50,
     },
     {
       id: 'maximum-hunter',
-      title: '180 Hunter',
-      description: 'Stack maximum visits and move toward elite scoring form.',
+      title: 'Chasseur de 180',
+      description: 'Enchaine les scores max pour entrer dans une vraie forme d\'elite.',
       progress: stats.total180s,
       maxProgress: 25,
       unlocked: stats.total180s >= 25,
     },
     {
       id: 'grind-setter',
-      title: 'Board Regular',
-      description: 'Keep logging matches to establish a serious sample size.',
+      title: 'Habitude du Board',
+      description: 'Continue d\'enregistrer des matchs pour construire un vrai volume.',
       progress: totalMatches,
       maxProgress: 30,
       unlocked: totalMatches >= 30,
@@ -332,24 +332,24 @@ function buildChallenges(records: MatchRecord[], stats: PlayerStats): Challenge[
   return [
     {
       id: 'play-three-today',
-      title: 'Three Match Warmup',
-      description: 'Play 3 registered matches today.',
+      title: 'Echauffement en 3 Matchs',
+      description: 'Joue 3 matchs enregistres aujourd\'hui.',
       progress: todayMatches,
       target: 3,
       reward: '+120 XP',
     },
     {
       id: 'checkout-80',
-      title: 'Big Finish',
-      description: 'Land a checkout above 80 in your tracked history.',
+      title: 'Gros Finish',
+      description: 'Reussis un checkout au-dessus de 80 dans ton historique suivi.',
       progress: hasCheckout80,
       target: 1,
       reward: 'Finisher badge',
     },
     {
       id: 'cricket-win',
-      title: 'Cricket Hunter',
-      description: 'Win one Cricket match.',
+      title: 'Chasseur de Cricket',
+      description: 'Gagne un match de Cricket.',
       progress: cricketWin,
       target: 1,
       reward: '+1 streak',
@@ -374,15 +374,15 @@ function buildQuickReplay(records: MatchRecord[], favoriteMode: LobbyGameMode): 
   if (latestMode === 'Cricket') {
     return {
       title: 'Relancer un Cricket',
-      description: 'Your latest logged match was a Cricket board. Jump straight back into marks and pressure scoring.',
-      cta: 'Start Cricket Again',
+      description: 'Ton dernier match enregistre etait un Cricket. Replonge directement dans les marques et le scoring sous pression.',
+      cta: 'Relancer un Cricket',
     };
   }
 
   return {
     title: 'Relancer un 501',
-    description: 'Return to the fastest competitive format and pick up where your recent scoring rhythm left off.',
-    cta: 'Start 501 Rematch',
+    description: 'Reviens au format competitif le plus rapide et reprends sur le rythme de score de tes dernieres parties.',
+    cta: 'Relancer un 501',
   };
 }
 

--- a/src/lib/lobbyMockData.ts
+++ b/src/lib/lobbyMockData.ts
@@ -20,7 +20,7 @@ export function buildLobbyData(user: any): LobbyData {
     avatarUrl,
     countryCode,
     countryFlag,
-    rank: 'County Elite',
+    rank: 'Elite Regionale',
     level: 18,
     xp: 1460,
     xpToNextLevel: 1800,
@@ -46,16 +46,16 @@ export function buildLobbyData(user: any): LobbyData {
   };
 
   const recentMatches: MatchHistoryItem[] = [
-    { id: 'm1', mode: 'X01', opponentLabel: 'vs zedart', scoreLabel: '3 - 1', playedAt: 'Today, 21:12', result: 'win' },
-    { id: 'm2', mode: 'Cricket', opponentLabel: 'vs bullforge', scoreLabel: '112 - 96', playedAt: 'Today, 19:48', result: 'loss' },
-    { id: 'm3', mode: 'Capital', opponentLabel: 'vs maya_d16', scoreLabel: '142 - 138', playedAt: 'Yesterday, 23:05', result: 'win' },
-    { id: 'm4', mode: 'Triathlon', opponentLabel: '3-player lobby', scoreLabel: '2nd place', playedAt: 'Yesterday, 20:31', result: 'loss' },
+    { id: 'm1', mode: 'X01', opponentLabel: 'vs zedart', scoreLabel: '3 - 1', playedAt: 'Aujourd\'hui, 21:12', result: 'win' },
+    { id: 'm2', mode: 'Cricket', opponentLabel: 'vs bullforge', scoreLabel: '112 - 96', playedAt: 'Aujourd\'hui, 19:48', result: 'loss' },
+    { id: 'm3', mode: 'Capital', opponentLabel: 'vs maya_d16', scoreLabel: '142 - 138', playedAt: 'Hier, 23:05', result: 'win' },
+    { id: 'm4', mode: 'Triathlon', opponentLabel: 'Lobby a 3 joueurs', scoreLabel: '2e place', playedAt: 'Hier, 20:31', result: 'loss' },
   ];
 
   const friends: FriendStatus[] = [
-    { id: 'f1', username: 'bullforge', avatarUrl: avatar(1), status: 'online', activity: 'Ready for a 501 set' },
-    { id: 'f2', username: 'maya_d16', avatarUrl: avatar(2), status: 'in_match', activity: 'Playing Cricket' },
-    { id: 'f3', username: 'triple20tom', avatarUrl: avatar(3), status: 'idle', activity: 'Last seen 12 min ago' },
+    { id: 'f1', username: 'bullforge', avatarUrl: avatar(1), status: 'online', activity: 'Pret pour un 501' },
+    { id: 'f2', username: 'maya_d16', avatarUrl: avatar(2), status: 'in_match', activity: 'Joue en Cricket' },
+    { id: 'f3', username: 'triple20tom', avatarUrl: avatar(3), status: 'idle', activity: 'Vu il y a 12 min' },
   ];
 
   const invites: LobbyInvite[] = [
@@ -64,20 +64,20 @@ export function buildLobbyData(user: any): LobbyData {
   ];
 
   const joinableLobbies: JoinableLobby[] = [
-    { id: 'l1', host: 'zedart', mode: 'X01', stakes: 'Best of 5 · Double Out', players: '1 / 2' },
-    { id: 'l2', host: 'club_night', mode: 'Triathlon', stakes: 'Mixed ladder', players: '2 / 4' },
+    { id: 'l1', host: 'zedart', mode: 'X01', stakes: 'BO5 · Double Out', players: '1 / 2' },
+    { id: 'l2', host: 'club_night', mode: 'Triathlon', stakes: 'Ladder mixte', players: '2 / 4' },
   ];
 
   const achievements: Achievement[] = [
-    { id: 'a1', title: 'Ton Plus Haut Checkout', description: 'Close a leg above 100', progress: 126, maxProgress: 170, unlocked: true },
-    { id: 'a2', title: 'Pressure Finisher', description: 'Win 10 matches with 30%+ checkout', progress: 7, maxProgress: 10, unlocked: false },
-    { id: 'a3', title: '180 Collector', description: 'Hit 50 maximums in total', progress: 47, maxProgress: 50, unlocked: false },
+    { id: 'a1', title: 'Ton Plus Haut Checkout', description: 'Finir une manche au-dessus de 100', progress: 126, maxProgress: 170, unlocked: true },
+    { id: 'a2', title: 'Finisseur Sous Pression', description: 'Gagner 10 matchs avec 30%+ de checkout', progress: 7, maxProgress: 10, unlocked: false },
+    { id: 'a3', title: 'Collectionneur de 180', description: 'Atteindre 50 scores max au total', progress: 47, maxProgress: 50, unlocked: false },
   ];
 
   const challenges: Challenge[] = [
-    { id: 'c1', title: 'Three Match Warmup', description: 'Play 3 matches today', progress: 1, target: 3, reward: '+120 XP' },
-    { id: 'c2', title: 'Big Finish', description: 'Hit a checkout above 80', progress: 0, target: 1, reward: 'Gold badge shard' },
-    { id: 'c3', title: 'Cricket Hunter', description: 'Win one Cricket match', progress: 0, target: 1, reward: '+1 daily streak' },
+    { id: 'c1', title: 'Echauffement en 3 Matchs', description: 'Jouer 3 matchs aujourd\'hui', progress: 1, target: 3, reward: '+120 XP' },
+    { id: 'c2', title: 'Gros Finish', description: 'Reussir un checkout au-dessus de 80', progress: 0, target: 1, reward: 'Eclat de badge or' },
+    { id: 'c3', title: 'Chasseur de Cricket', description: 'Gagner un match de Cricket', progress: 0, target: 1, reward: '+1 serie quotidienne' },
   ];
 
   return {
@@ -92,7 +92,7 @@ export function buildLobbyData(user: any): LobbyData {
     quickReplay: {
       title: 'Relancer un 501',
       description: 'Ton dernier mode joue et ton meilleur ratio de victoire cette semaine.',
-      cta: 'Start 501 Rematch',
+      cta: 'Relancer un 501',
     },
   };
 }

--- a/types.ts
+++ b/types.ts
@@ -89,7 +89,7 @@ export interface CricketPlayerState {
 
 // --- Capital Types ---
 
-export type CapitalTarget = 'CAPITAL' | '20' | 'COTE_A_COTE' | '19' | 'SUITE' | '18' | 'COULEUR' | '17' | 'DOUBLE' | '16' | 'TRIPLE' | '15' | '57' | '14' | 'CENTRE';
+export type CapitalTarget = 'CAPITAL' | '20' | 'COTE_A_COTE' | '19' | 'SUITE' | '18' | '17' | 'DOUBLE' | '16' | 'TRIPLE' | '15' | '57' | '17_OU_MOINS' | 'COULEUR' | '14' | 'CENTRE';
 
 export interface CapitalDart {
   value: number; // 0-20, 25
@@ -107,7 +107,7 @@ export interface CapitalPlayerState {
   id: string;
   name: string;
   score: number;
-  targetIndex: number; // 0 to 14
+  targetIndex: number; // 0 to 15
   history: CapitalHistoryItem[];
 }
 

--- a/utils/capitalLogic.ts
+++ b/utils/capitalLogic.ts
@@ -1,7 +1,7 @@
 import { CapitalDart, CapitalTarget } from '../types';
 
 export const CAPITAL_TARGETS: CapitalTarget[] = [
-  'CAPITAL', '20', 'COTE_A_COTE', '19', 'SUITE', '18', 'COULEUR', '17', 'DOUBLE', '16', 'TRIPLE', '15', '57', '14', 'CENTRE'
+  'CAPITAL', '20', 'COTE_A_COTE', '19', 'SUITE', '18', '17', 'DOUBLE', '16', 'TRIPLE', '15', '57', '17_OU_MOINS', 'COULEUR', '14', 'CENTRE'
 ];
 
 export const CAPITAL_TARGET_NAMES: Record<CapitalTarget, string> = {
@@ -11,13 +11,14 @@ export const CAPITAL_TARGET_NAMES: Record<CapitalTarget, string> = {
   '19': 'Le 19',
   'SUITE': 'La Suite',
   '18': 'Le 18',
-  'COULEUR': 'La Couleur',
   '17': 'Le 17',
   'DOUBLE': 'Le Double',
   '16': 'Le 16',
   'TRIPLE': 'Le Triple',
   '15': 'Le 15',
   '57': 'Le 57',
+  '17_OU_MOINS': '17 Points ou Moins',
+  'COULEUR': 'La Couleur',
   '14': 'Le 14',
   'CENTRE': 'Le Centre'
 };
@@ -35,6 +36,17 @@ function getDartColor(dart: CapitalDart): 'BLACK' | 'WHITE' | 'RED' | 'GREEN' | 
   } else {
     return isBlackSingle ? 'RED' : 'GREEN';
   }
+}
+
+export function shouldResolveCapitalRound(target: CapitalTarget, darts: CapitalDart[]): boolean {
+  if (darts.length === 0) return false;
+
+  if (target === '57') {
+    const total = darts.reduce((sum, dart) => sum + (dart.value * dart.multiplier), 0);
+    return total >= 57 || darts.length === 3;
+  }
+
+  return darts.length === 3;
 }
 
 export function evaluateCapitalRound(target: CapitalTarget, darts: CapitalDart[], currentScore: number): { newScore: number, pointsScored: number, isSuccess: boolean } {
@@ -86,14 +98,6 @@ export function evaluateCapitalRound(target: CapitalTarget, darts: CapitalDart[]
         }
       }
       break;
-    case 'COULEUR':
-      const colors = darts.map(getDartColor).filter(c => c !== 'NONE');
-      const uniqueColors = new Set(colors);
-      if (uniqueColors.size === 3 && darts.length === 3) {
-        isSuccess = true;
-        pointsScored = totalDartsScore;
-      }
-      break;
     case 'DOUBLE':
       const doubles = darts.filter(d => d.multiplier === 2 && d.value > 0);
       if (doubles.length > 0) {
@@ -112,6 +116,20 @@ export function evaluateCapitalRound(target: CapitalTarget, darts: CapitalDart[]
       if (totalDartsScore === 57 && darts.some(d => d.value > 0)) {
         isSuccess = true;
         pointsScored = 57;
+      }
+      break;
+    case '17_OU_MOINS':
+      if (darts.length === 3 && totalDartsScore <= 17) {
+        isSuccess = true;
+        pointsScored = totalDartsScore;
+      }
+      break;
+    case 'COULEUR':
+      const colors = darts.map(getDartColor).filter(c => c !== 'NONE');
+      const uniqueColors = new Set(colors);
+      if (uniqueColors.size === 3 && darts.length === 3) {
+        isSuccess = true;
+        pointsScored = totalDartsScore;
       }
       break;
     case 'CENTRE':

--- a/views/AuthView.tsx
+++ b/views/AuthView.tsx
@@ -50,7 +50,7 @@ const SocialAuthButton: React.FC<SocialAuthButtonProps> = ({ label, provider, on
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
-      title={disabled ? `${label} coming soon` : label}
+      title={disabled ? `${label} bientot disponible` : label}
       className={`group relative flex h-12 w-12 items-center justify-center rounded-2xl border transition-all duration-200 ${
         disabled
           ? 'cursor-not-allowed border-gray-800 bg-gray-900/60 text-gray-600 opacity-60'
@@ -60,7 +60,7 @@ const SocialAuthButton: React.FC<SocialAuthButtonProps> = ({ label, provider, on
       <span className="transition-transform duration-200 group-hover:scale-105">{iconMap[provider]}</span>
       {disabled && (
         <span className="absolute -bottom-2 rounded-full border border-gray-800 bg-black px-2 py-0.5 text-[8px] font-black uppercase tracking-[0.2em] text-gray-500">
-          Soon
+          Bientot
         </span>
       )}
     </button>
@@ -109,14 +109,14 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                 if (data.session) {
                     onLoginSuccess(data.user);
                 } else {
-                    setErrorMsg("Account created! Please check your email to confirm.");
+                    setErrorMsg("Compte cree. Verifie ton email pour confirmer.");
                     setIsLoading(false);
                     return;
                 }
             }
         }
     } catch (err: any) {
-        setErrorMsg(err.message || "An error occurred");
+        setErrorMsg(err.message || "Une erreur est survenue");
         setIsLoading(false);
     }
   };
@@ -129,16 +129,16 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
       const { error } = await signInWithGoogle();
       if (error) throw error;
     } catch (err: any) {
-      setErrorMsg(err.message || 'Google sign-in failed.');
+      setErrorMsg(err.message || 'La connexion Google a echoue.');
       setIsLoading(false);
     }
   };
 
   const isLogin = mode === 'LOGIN';
-  const title = isLogin ? 'Access Your Arena' : 'Create Your Player Space';
+  const title = isLogin ? 'Accede A Ton Arena' : 'Cree Ton Espace Joueur';
   const subtitle = isLogin
-    ? 'Recover your profile, your match history and your cross-device stats in seconds.'
-    : 'Create your account to sync your matches, save your identity and build your long-term stats.';
+    ? 'Recupere ton profil, ton historique de matchs et tes stats multi-appareils en quelques secondes.'
+    : 'Cree ton compte pour synchroniser tes matchs, sauvegarder ton identite et construire tes stats sur la duree.';
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#04060a] text-white">
@@ -154,7 +154,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
             className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-[11px] font-black uppercase tracking-[0.22em] text-gray-300 transition-all hover:border-orange-400/30 hover:bg-white/[0.07] hover:text-white"
           >
             <ChevronLeft className="h-4 w-4" />
-            Back
+            Retour
           </button>
         </div>
 
@@ -165,7 +165,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
               <div className="space-y-6">
                 <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.26em] text-orange-200">
                   <span className="h-2 w-2 rounded-full bg-orange-400 shadow-[0_0_12px_rgba(251,146,60,0.8)]" />
-                  Player Access
+                  Acces Joueur
                 </div>
 
                 <div className="space-y-4 text-center">
@@ -181,14 +181,14 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                   <div className="flex flex-wrap items-center justify-center gap-3 sm:flex-nowrap sm:gap-4">
                     <div className="h-[2px] w-10 rounded-full bg-gradient-to-r from-orange-500 via-red-500 to-transparent" />
                     <p className="bg-gradient-to-r from-orange-100 via-white to-orange-300 bg-clip-text text-[10px] font-black uppercase tracking-[0.28em] text-transparent sm:text-[12px] sm:tracking-[0.36em]">
-                      Professional Darts Scoring App
+                      Application de score de flechettes
                     </p>
                     <div className="hidden h-[2px] w-10 rounded-full bg-gradient-to-l from-orange-500 via-red-500 to-transparent sm:block" />
                   </div>
 
                   <p className="mx-auto max-w-xl text-sm leading-7 text-gray-300 sm:text-base lg:text-lg">
-                    Access your player space, sync your match history and keep your performance data
-                    available from desktop, tablet and mobile.
+                    Accede a ton espace joueur, synchronise ton historique et garde tes donnees de performance
+                    disponibles sur ordinateur, tablette et mobile.
                   </p>
                 </div>
               </div>
@@ -200,7 +200,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
             <div className="relative">
               <div className="mb-6 flex items-start justify-between gap-4">
                 <div>
-                  <p className="text-[11px] font-black uppercase tracking-[0.28em] text-orange-300">Account Access</p>
+                  <p className="text-[11px] font-black uppercase tracking-[0.28em] text-orange-300">Acces Compte</p>
                   <h1 className="mt-3 text-3xl font-black italic tracking-tight text-white sm:text-4xl">
                     {title}
                   </h1>
@@ -209,7 +209,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                   </p>
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/[0.05] px-3 py-2 text-[10px] font-black uppercase tracking-[0.24em] text-gray-400">
-                  {isLogin ? 'Login' : 'Sign Up'}
+                  {isLogin ? 'Connexion' : 'Inscription'}
                 </div>
               </div>
 
@@ -231,7 +231,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                     mode === 'LOGIN' ? 'text-white' : 'text-gray-500'
                   }`}
                 >
-                  Log In
+                  Connexion
                 </button>
                 <button
                   onClick={() => setMode('SIGNUP')}
@@ -239,7 +239,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                     mode === 'SIGNUP' ? 'text-white' : 'text-gray-500'
                   }`}
                 >
-                  Sign Up
+                  Inscription
                 </button>
               </div>
 
@@ -257,7 +257,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                   </FieldShell>
                 )}
 
-                <FieldShell label="Email Address">
+                <FieldShell label="Adresse Email">
                   <input
                     type="email"
                     value={email}
@@ -268,7 +268,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                   />
                 </FieldShell>
 
-                <FieldShell label="Password">
+                <FieldShell label="Mot De Passe">
                   <input
                     type="password"
                     value={password}
@@ -288,7 +288,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
                     {isLoading ? (
                       <div className="h-6 w-6 rounded-full border-2 border-white/30 border-t-white animate-spin" />
                     ) : (
-                      isLogin ? 'Enter Arena' : 'Create Account'
+                      isLogin ? 'Entrer Dans L\'Arena' : 'Creer Le Compte'
                     )}
                   </Button>
                 </div>
@@ -296,31 +296,31 @@ export const AuthView: React.FC<AuthViewProps> = ({ onLoginSuccess, onBack }) =>
 
               <div className="my-6 flex items-center gap-3">
                 <div className="h-px flex-1 bg-white/8" />
-                <span className="text-[10px] font-black uppercase tracking-[0.3em] text-gray-500">or continue with</span>
+                <span className="text-[10px] font-black uppercase tracking-[0.3em] text-gray-500">ou continuer avec</span>
                 <div className="h-px flex-1 bg-white/8" />
               </div>
 
               <div className="rounded-[1.6rem] border border-white/8 bg-black/20 p-4 sm:p-5">
                 <div className="flex items-center justify-center gap-3">
                   <SocialAuthButton
-                    label="Continue with Google"
+                    label="Continuer avec Google"
                     provider="google"
                     onClick={handleGoogleLogin}
                     disabled={isLoading}
                   />
                   <SocialAuthButton
-                    label="Continue with Apple"
+                    label="Continuer avec Apple"
                     provider="apple"
                     disabled
                   />
                   <SocialAuthButton
-                    label="Continue with Facebook"
+                    label="Continuer avec Facebook"
                     provider="facebook"
                     disabled
                   />
                 </div>
                 <p className="mt-4 text-center text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-                  Google is available now. Apple and Facebook will stay disabled until configured.
+                  Google est disponible maintenant. Apple et Facebook resteront desactives jusqu'a leur configuration.
                 </p>
               </div>
             </div>

--- a/views/CapitalGameView.tsx
+++ b/views/CapitalGameView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Player, CapitalPlayerState, CapitalDart } from '../types';
-import { CAPITAL_TARGETS, CAPITAL_TARGET_NAMES, evaluateCapitalRound } from '../utils/capitalLogic';
+import { CAPITAL_TARGETS, CAPITAL_TARGET_NAMES, evaluateCapitalRound, shouldResolveCapitalRound } from '../utils/capitalLogic';
 import { CapitalKeypad } from '../components/game/CapitalKeypad';
 import { Button } from '../components/ui/Button';
 
@@ -35,7 +35,7 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, onExi
     const newDarts = [...currentDarts, dart];
     setCurrentDarts(newDarts);
 
-    if (newDarts.length === 3) {
+    if (shouldResolveCapitalRound(currentTarget, newDarts)) {
       setTimeout(() => {
         const { newScore, pointsScored, isSuccess } = evaluateCapitalRound(currentTarget, newDarts, currentPlayer.score);
         
@@ -95,7 +95,7 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, onExi
   }
 
   return (
-    <div className="flex h-[100dvh] flex-col overflow-hidden bg-gradient-to-br from-gray-900 to-black text-white">
+    <div className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-gradient-to-br from-gray-900 to-black text-white">
       {/* Header */}
       <div className="z-20 flex min-h-12 shrink-0 items-center justify-between border-b border-gray-800 bg-gray-900 px-3 py-2 sm:px-4">
         <div className="font-black italic text-base sm:text-lg">
@@ -107,19 +107,19 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, onExi
       </div>
 
       {/* Main Game Area */}
-      <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-3 sm:p-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 sm:gap-4 sm:p-4">
         {/* Current Target Info */}
-        <div className="bg-gray-800/50 border border-orange-900/30 rounded-xl p-4 text-center shadow-lg">
+        <div className="rounded-xl border border-orange-900/30 bg-gray-800/50 p-3 text-center shadow-lg sm:p-4">
           <div className="text-sm text-orange-400 font-bold uppercase tracking-widest mb-1">Objectif Actuel</div>
           <div className="text-2xl font-black italic text-white sm:text-3xl">{CAPITAL_TARGET_NAMES[currentTarget]}</div>
         </div>
 
         {/* Players List */}
-        <div className="flex flex-col gap-2">
+        <div className="flex min-h-0 flex-col gap-2">
           {states.map((p, idx) => (
             <div 
               key={p.id} 
-              className={`flex justify-between items-center p-3 rounded-lg border transition-all ${
+              className={`flex items-center justify-between rounded-lg border p-2.5 transition-all sm:p-3 ${
                 idx === currentPlayerIdx 
                   ? 'bg-orange-900/20 border-orange-500 shadow-[0_0_10px_rgba(249,115,22,0.2)]' 
                   : 'bg-gray-900/50 border-gray-800 opacity-60'
@@ -139,13 +139,13 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, onExi
         </div>
 
         {/* Current Darts */}
-        <div className="mb-2 mt-auto flex justify-center gap-3 sm:gap-4">
+        <div className="mb-1 mt-auto flex justify-center gap-2.5 sm:mb-2 sm:gap-4">
           {[0, 1, 2].map(i => {
             const dart = currentDarts[i];
             return (
               <div 
                 key={i} 
-                className={`flex h-14 w-14 items-center justify-center rounded-full border-2 text-base font-black sm:h-16 sm:w-16 sm:text-xl ${
+                className={`flex h-12 w-12 items-center justify-center rounded-full border-2 text-sm font-black sm:h-16 sm:w-16 sm:text-xl ${
                   dart 
                     ? 'bg-gray-800 border-orange-500 text-white shadow-[0_0_10px_rgba(249,115,22,0.3)]' 
                     : 'bg-gray-900 border-gray-700 text-gray-600'
@@ -163,7 +163,7 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, onExi
       </div>
 
       {/* Keypad */}
-      <div className="z-30 h-[34svh] min-h-[290px] shrink-0 pb-safe md:h-[38svh]">
+      <div className="z-30 h-[clamp(15rem,31svh,22rem)] shrink-0 pb-safe md:h-[clamp(16rem,34svh,24rem)]">
         <CapitalKeypad 
           onDartInput={handleDartInput} 
           onUndo={handleUndo} 

--- a/views/ChallengeFriendView.tsx
+++ b/views/ChallengeFriendView.tsx
@@ -98,7 +98,7 @@ export const ChallengeFriendView: React.FC<ChallengeFriendViewProps> = ({
                   Defier Un Ami
                 </h1>
                 <p className="mt-2 max-w-2xl text-sm text-gray-400 sm:text-base">
-                  Pick a friend, lock a format and send a competitive invitation straight from the lobby.
+                  Choisis un ami, verrouille un format et envoie une invitation competitive directement depuis le lobby.
                 </p>
               </div>
             </div>
@@ -114,7 +114,7 @@ export const ChallengeFriendView: React.FC<ChallengeFriendViewProps> = ({
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search a friend"
+                placeholder="Rechercher un ami"
                 className="w-full bg-transparent text-sm font-bold text-white outline-none placeholder:text-gray-600"
               />
             </div>
@@ -125,7 +125,7 @@ export const ChallengeFriendView: React.FC<ChallengeFriendViewProps> = ({
               </div>
             ) : filteredFriends.length === 0 ? (
               <div className="rounded-[1.5rem] border border-dashed border-white/10 bg-black/20 px-4 py-10 text-center text-sm text-gray-400">
-                No friends available for a direct challenge yet.
+                Aucun ami disponible pour un defi direct pour le moment.
               </div>
             ) : (
               <div className="space-y-3">

--- a/views/CreateLobbyView.tsx
+++ b/views/CreateLobbyView.tsx
@@ -25,8 +25,8 @@ export const CreateLobbyView: React.FC<CreateLobbyViewProps> = ({
   onCreated,
 }) => {
   const [mode, setMode] = useState<LobbyGameMode>('X01');
-  const [title, setTitle] = useState('Evening 501 Set');
-  const [stakes, setStakes] = useState('Best of 5 · Double Out');
+  const [title, setTitle] = useState('Set 501 du Soir');
+  const [stakes, setStakes] = useState('BO5 · Double Out');
   const [maxPlayers, setMaxPlayers] = useState(2);
   const [startingScore, setStartingScore] = useState(501);
   const [matchMode, setMatchMode] = useState<MatchMode>('LEGS');
@@ -83,11 +83,11 @@ export const CreateLobbyView: React.FC<CreateLobbyViewProps> = ({
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Host Setup
+                Configuration Hote
               </div>
               <div>
                 <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">
@@ -152,17 +152,17 @@ export const CreateLobbyView: React.FC<CreateLobbyViewProps> = ({
                     value={title}
                     onChange={(e) => setTitle(e.target.value)}
                     className="w-full bg-transparent text-base font-black text-white outline-none"
-                    placeholder="Evening 501 Set"
+                    placeholder="Set 501 du Soir"
                   />
                 </div>
                 <div className="rounded-[1.4rem] border border-white/8 bg-black/20 px-4 py-3">
-                  <div className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Stakes</div>
+                  <div className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Format</div>
                   <input
                     type="text"
                     value={stakes}
                     onChange={(e) => setStakes(e.target.value)}
                     className="w-full bg-transparent text-base font-bold text-white outline-none"
-                    placeholder="Best of 5 · Double Out"
+                    placeholder="BO5 · Double Out"
                   />
                 </div>
               </div>
@@ -171,7 +171,7 @@ export const CreateLobbyView: React.FC<CreateLobbyViewProps> = ({
             {mode === 'X01' && (
               <div className="rounded-[2rem] border border-white/10 bg-[#101722]/86 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.22)] backdrop-blur-xl sm:p-6">
                 <div className="mb-5">
-                  <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Game Config</p>
+                  <p className="text-[10px] font-black uppercase tracking-[0.28em] text-orange-300">Configuration Du Jeu</p>
                   <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Regles X01</h2>
                 </div>
 
@@ -346,11 +346,11 @@ export const CreateLobbyView: React.FC<CreateLobbyViewProps> = ({
                 </div>
                 <div className="rounded-[1.4rem] border border-white/8 bg-black/20 p-4">
                   <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Titre</div>
-                  <div className="mt-2 text-lg font-black text-white">{title || 'Open Match'}</div>
+                  <div className="mt-2 text-lg font-black text-white">{title || 'Match Ouvert'}</div>
                 </div>
                 <div className="rounded-[1.4rem] border border-white/8 bg-black/20 p-4">
                   <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Stakes</div>
-                  <div className="mt-2 text-sm text-gray-300">{stakes || 'Open match'}</div>
+                  <div className="mt-2 text-sm text-gray-300">{stakes || 'Match ouvert'}</div>
                 </div>
                 <div className="rounded-[1.4rem] border border-white/8 bg-black/20 p-4">
                   <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Capacity</div>

--- a/views/CricketGameView.tsx
+++ b/views/CricketGameView.tsx
@@ -98,7 +98,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, onExi
     }
 
     return (
-        <div className="flex h-[100dvh] flex-col overflow-hidden bg-gradient-to-br from-gray-900 to-black text-white">
+        <div className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-gradient-to-br from-gray-900 to-black text-white">
              {/* Header */}
             <div className="z-20 flex min-h-12 shrink-0 items-center justify-between border-b border-gray-800 bg-gray-900 px-3 py-2 sm:px-4">
                 <div className="font-black italic text-base sm:text-lg">
@@ -117,12 +117,12 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, onExi
             </div>
 
             {/* Scoreboard - Takes available space */}
-            <div className="flex-1 overflow-hidden relative">
+            <div className="relative min-h-0 flex-1 overflow-hidden">
                 <CricketScoreboard players={states} currentPlayerId={currentPlayer.id} />
             </div>
 
             {/* Keypad Area - Fixed height for usability */}
-            <div className="z-30 h-[34svh] min-h-[290px] shrink-0 pb-safe md:h-[38svh]">
+            <div className="z-30 h-[clamp(15rem,31svh,22rem)] shrink-0 pb-safe md:h-[clamp(16rem,34svh,24rem)]">
                 <CricketKeypad 
                     onHit={handleHit} 
                     onMiss={handleMiss} 

--- a/views/DashboardView.tsx
+++ b/views/DashboardView.tsx
@@ -28,7 +28,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
           </div>
           <div>
             <h1 className="text-xl font-black italic text-transparent bg-clip-text bg-gradient-to-r from-white to-gray-400 sm:text-2xl">
-              HELLO,
+              BONJOUR,
             </h1>
             <h2 className="text-lg font-black text-orange-500 uppercase tracking-wider sm:text-xl">
               {username}
@@ -51,20 +51,20 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
           <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/carbon-fibre.png')] opacity-10" />
           <span className="relative z-10 flex items-center gap-3 sm:gap-4">
             <span className="text-3xl group-hover:rotate-12 transition-transform duration-300 sm:text-5xl">🎯</span>
-            PLAY NOW
+            JOUER
           </span>
         </Button>
       </div>
 
       <div className="grid w-full max-w-lg grid-cols-1 gap-4 mx-auto sm:grid-cols-2">
-        <MenuCard title="My Stats" icon="📊" desc="Averages & PBs" onClick={onStats} color="blue" />
-        <MenuCard title="History" icon="clock" desc="Match Logs" onClick={onHistory} color="green" isSvg />
-        <MenuCard title="My Account" icon="user" desc="Profile Details" onClick={onProfile} color="purple" isSvg />
+        <MenuCard title="Mes Stats" icon="📊" desc="Moyennes et records" onClick={onStats} color="blue" />
+        <MenuCard title="Historique" icon="clock" desc="Journal des matchs" onClick={onHistory} color="green" isSvg />
+        <MenuCard title="Mon Compte" icon="user" desc="Details du profil" onClick={onProfile} color="purple" isSvg />
       </div>
 
       <div className="mt-auto text-center pt-8 pb-4">
         <p className="text-[10px] text-gray-600 font-mono uppercase tracking-widest">
-          Bougnat Darts Club Member
+          Membre du Bougnat Darts Club
         </p>
       </div>
     </div>

--- a/views/FriendsManagementView.tsx
+++ b/views/FriendsManagementView.tsx
@@ -121,12 +121,12 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
     const { error } = await createFriendRequest(user.id, player.user_id);
 
     if (error) {
-      setFeedback({ type: 'error', text: error.message || 'Unable to send the friend request.' });
+      setFeedback({ type: 'error', text: error.message || 'Impossible d\'envoyer la demande d\'ami.' });
       setIsSubmitting(false);
       return;
     }
 
-    setFeedback({ type: 'success', text: `${player.username} received your friend request.` });
+    setFeedback({ type: 'success', text: `${player.username} a bien recu ta demande d'ami.` });
     await loadData();
     setIsSubmitting(false);
   };
@@ -137,12 +137,12 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
     const { error } = await createEmailFriendInvite(user.id, inviteEmail);
 
     if (error) {
-      setFeedback({ type: 'error', text: error.message || 'Unable to create the email invite.' });
+      setFeedback({ type: 'error', text: error.message || 'Impossible de creer l\'invitation email.' });
       setIsSubmitting(false);
       return;
     }
 
-    setFeedback({ type: 'success', text: `Invitation prepared for ${inviteEmail.trim().toLowerCase()}.` });
+    setFeedback({ type: 'success', text: `Invitation preparee pour ${inviteEmail.trim().toLowerCase()}.` });
     setInviteEmail('');
     await loadData();
     setIsSubmitting(false);
@@ -154,12 +154,12 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
     const { error } = await removeFriendship(user.id, friendId);
 
     if (error) {
-      setFeedback({ type: 'error', text: error.message || 'Unable to remove this friend.' });
+      setFeedback({ type: 'error', text: error.message || 'Impossible de retirer cet ami.' });
       setIsSubmitting(false);
       return;
     }
 
-    setFeedback({ type: 'success', text: `${username} has been removed from your friends list.` });
+    setFeedback({ type: 'success', text: `${username} a ete retire de ta liste d'amis.` });
     await loadData();
     setIsSubmitting(false);
   };
@@ -170,14 +170,14 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
     const { error } = await respondToFriendRequest(requestId, decision);
 
     if (error) {
-      setFeedback({ type: 'error', text: error.message || 'Unable to update the request.' });
+      setFeedback({ type: 'error', text: error.message || 'Impossible de mettre a jour la demande.' });
       setIsSubmitting(false);
       return;
     }
 
     setFeedback({
       type: 'success',
-      text: decision === 'accepted' ? 'Friend request accepted.' : 'Friend request declined.',
+      text: decision === 'accepted' ? 'Demande d\'ami acceptee.' : 'Demande d\'ami refusee.',
     });
     await loadData();
     setIsSubmitting(false);
@@ -192,11 +192,11 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Friends Control
+                Gestion Des Amis
               </div>
               <div>
                 <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">
@@ -283,7 +283,7 @@ export const FriendsManagementView: React.FC<FriendsManagementViewProps> = ({
                                 {player.username}
                               </div>
                             </div>
-                            <div className="mt-1 text-sm text-gray-500">Player already available in Bougnat Darts</div>
+                            <div className="mt-1 text-sm text-gray-500">Joueur deja disponible dans Bougnat Darts</div>
                           </div>
                         </div>
                         <Button

--- a/views/GameSelectionView.tsx
+++ b/views/GameSelectionView.tsx
@@ -149,9 +149,9 @@ export const GameSelectionView: React.FC<GameSelectionViewProps> = ({
             </div>
 
             <div className="space-y-3">
-              <p className="text-[11px] font-black uppercase tracking-[0.32em] text-orange-300">Arena Setup</p>
+              <p className="text-[11px] font-black uppercase tracking-[0.32em] text-orange-300">Configuration Arena</p>
               <h2 className="max-w-3xl text-3xl font-black uppercase tracking-[-0.04em] text-white sm:text-4xl lg:text-5xl">
-                Select Your Game Mode
+                Choisis Ton Mode De Jeu
               </h2>
             </div>
           </div>
@@ -168,8 +168,8 @@ export const GameSelectionView: React.FC<GameSelectionViewProps> = ({
                   <span className="text-sm font-black uppercase">ID</span>
                 </div>
                 <div>
-                  <p className="text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Account</p>
-                  <p className="mt-1 text-sm font-black uppercase tracking-[0.14em] text-white">Login / Sign Up</p>
+                  <p className="text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Compte</p>
+                  <p className="mt-1 text-sm font-black uppercase tracking-[0.14em] text-white">Connexion / Inscription</p>
                 </div>
               </button>
             )
@@ -205,7 +205,7 @@ export const GameSelectionView: React.FC<GameSelectionViewProps> = ({
                       </span>
                       {game.featured && (
                         <span className="rounded-full border border-orange-400/20 bg-orange-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] text-orange-200">
-                          Featured
+                          A La Une
                         </span>
                       )}
                     </div>
@@ -225,10 +225,10 @@ export const GameSelectionView: React.FC<GameSelectionViewProps> = ({
                   <div className="flex items-center justify-between border-t border-white/10 pt-4">
                     <div className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.22em] text-gray-500">
                       <Gauge className="h-4 w-4" />
-                      Ready to launch
+                      Pret A Lancer
                     </div>
                     <div className="inline-flex items-center gap-2 text-sm font-black uppercase tracking-[0.18em] text-white">
-                      Play
+                      Jouer
                       <ChevronRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
                     </div>
                   </div>

--- a/views/HistoryView.tsx
+++ b/views/HistoryView.tsx
@@ -61,7 +61,7 @@ export const HistoryView: React.FC<HistoryViewProps> = ({ user, onBack, onOpenPr
             : 'border-red-500/30 bg-red-500/10 text-red-300'
         }`}
       >
-        {isWin ? 'Victory' : 'Defeat'}
+        {isWin ? 'Victoire' : 'Defaite'}
       </span>
     );
   };
@@ -72,18 +72,18 @@ export const HistoryView: React.FC<HistoryViewProps> = ({ user, onBack, onOpenPr
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Match History
+                Historique Des Matchs
               </div>
               <div>
                 <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">
-                  Your Recent Sessions
+                  Tes Sessions Recentes
                 </h1>
                 <p className="mt-2 max-w-2xl text-sm text-gray-400 sm:text-base">
-                  Review your latest results, formats and closing patterns before stepping back to the board.
+                  Revois tes derniers resultats, formats et schemas de finish avant de revenir au board.
                 </p>
               </div>
             </div>
@@ -101,24 +101,24 @@ export const HistoryView: React.FC<HistoryViewProps> = ({ user, onBack, onOpenPr
               <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl border border-orange-500/20 bg-orange-500/10 text-3xl">
                 📜
               </div>
-              <h2 className="text-2xl font-black uppercase tracking-[-0.04em] text-white">No matches recorded yet</h2>
+              <h2 className="text-2xl font-black uppercase tracking-[-0.04em] text-white">Aucun match enregistre pour le moment</h2>
               <p className="mt-3 text-sm text-gray-400">
-                Launch a game and your recent history will appear here automatically.
+                Lance une partie et ton historique recent apparaitra ici automatiquement.
               </p>
             </div>
           </div>
         ) : (
           <div className="grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
             <aside className="rounded-[2rem] border border-white/10 bg-[#0d131d]/88 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-xl">
-              <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">History Summary</div>
+              <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Resume Historique</div>
               <div className="mt-5 grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
-                <SummaryTile label="Logged Matches" value={String(matches.length)} hint="Across your stored sessions" />
+                <SummaryTile label="Matchs Enregistres" value={String(matches.length)} hint="Sur l'ensemble de tes sessions sauvegardees" />
                 <SummaryTile
-                  label="Latest Mode"
+                  label="Dernier Mode"
                   value={matches[0]?.game_name || matches[0]?.game_data?.gameName || matches[0]?.game_type || 'X01'}
-                  hint="Most recent format played"
+                  hint="Format joue le plus recemment"
                 />
-                <SummaryTile label="Last Session" value={formatDate(matches[0].created_at)} hint="Newest recorded game" />
+                <SummaryTile label="Derniere Session" value={formatDate(matches[0].created_at)} hint="Partie la plus recente enregistree" />
               </div>
             </aside>
 
@@ -161,15 +161,15 @@ export const HistoryView: React.FC<HistoryViewProps> = ({ user, onBack, onOpenPr
 
                     <div className="mt-5 grid gap-4 sm:grid-cols-[0.85fr_1.15fr]">
                       <div className="rounded-2xl border border-white/8 bg-black/20 p-4">
-                        <div className="text-[10px] font-black uppercase tracking-[0.22em] text-gray-500">Final Score</div>
+                        <div className="text-[10px] font-black uppercase tracking-[0.22em] text-gray-500">Score Final</div>
                         <div className="mt-3 text-4xl font-black tracking-[-0.05em] text-white">
                           {String(scoreFor)} <span className="text-gray-500">-</span> {String(scoreAgainst)}
                         </div>
                       </div>
                       <div className="grid gap-3 sm:grid-cols-2">
-                        <DetailTile label="Result" value={match.is_win ? p1Name : p2Name} />
+                        <DetailTile label="Resultat" value={match.is_win ? p1Name : p2Name} />
                         <DetailTile label="Format" value={match.match_mode || match.game_type} />
-                        <DetailTile label="Opening Score" value={match.starting_score ? String(match.starting_score) : '-'} />
+                        <DetailTile label="Score De Depart" value={match.starting_score ? String(match.starting_score) : '-'} />
                         <DetailTile label="Checkout" value={match.check_out ? `${match.check_out} Out` : '-'} />
                       </div>
                     </div>

--- a/views/HomeView.tsx
+++ b/views/HomeView.tsx
@@ -36,9 +36,9 @@ export const HomeView: React.FC<HomeViewProps> = ({
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(appUrl)}&bgcolor=ffffff&margin=5`;
 
   const statusLabel =
-    dbStatus === 'checking' ? 'Connecting...' :
-    dbStatus === 'ok' ? 'System online' :
-    'Offline mode';
+    dbStatus === 'checking' ? 'Connexion...' :
+    dbStatus === 'ok' ? 'Systeme en ligne' :
+    'Mode hors ligne';
 
   const statusTone =
     dbStatus === 'checking' ? 'bg-amber-400 shadow-[0_0_14px_rgba(251,191,36,0.7)]' :
@@ -46,9 +46,9 @@ export const HomeView: React.FC<HomeViewProps> = ({
     'bg-red-500 shadow-[0_0_14px_rgba(239,68,68,0.6)]';
 
   const footerStatusLabel =
-    dbStatus === 'checking' ? 'Connecting...' :
-    dbStatus === 'ok' ? 'System Online' :
-    'Offline Mode';
+    dbStatus === 'checking' ? 'Connexion...' :
+    dbStatus === 'ok' ? 'Systeme En Ligne' :
+    'Mode Hors Ligne';
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#05070b] text-white">
@@ -79,7 +79,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
                   <div className="mt-3 flex w-full flex-wrap items-center justify-center gap-3 sm:flex-nowrap sm:gap-4">
                     <div className="h-[2px] w-8 rounded-full bg-gradient-to-r from-orange-500 via-red-500 to-transparent sm:w-12" />
                     <p className="bg-gradient-to-r from-orange-100 via-white to-orange-300 bg-clip-text text-[10px] font-black uppercase tracking-[0.22em] text-transparent sm:text-[12px] sm:tracking-[0.38em]">
-                      Professional Darts Scoring App
+                      Application de score de flechettes
                     </p>
                     <div className="hidden h-[2px] w-12 rounded-full bg-gradient-to-l from-orange-500 via-red-500 to-transparent sm:block" />
                   </div>
@@ -100,7 +100,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
                 className="group h-14 w-full rounded-2xl px-5 text-base shadow-[0_16px_40px_rgba(234,88,12,0.3)] sm:h-16 sm:min-w-[230px] sm:px-6 sm:text-lg"
               >
                 <span className="inline-flex items-center gap-3">
-                  <span>Quick Game</span>
+                  <span>Partie Rapide</span>
                   <ChevronRight className="h-5 w-5 transition-transform duration-200 group-hover:translate-x-1" />
                 </span>
               </Button>
@@ -112,7 +112,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
                 className="group h-14 w-full rounded-2xl border-white/10 bg-white/[0.045] px-5 text-base text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] backdrop-blur-sm hover:border-orange-400/30 hover:bg-white/[0.08] sm:h-16 sm:min-w-[230px] sm:px-6 sm:text-lg"
               >
                 <span className="inline-flex items-center gap-3">
-                  <span>{secondaryLabel || 'Login / Sign Up'}</span>
+                  <span>{secondaryLabel || 'Connexion / Inscription'}</span>
                   <ChevronRight className="h-5 w-5 transition-transform duration-200 group-hover:translate-x-1" />
                 </span>
               </Button>
@@ -128,7 +128,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
             <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-gradient-to-br from-orange-500/20 to-red-500/20 text-orange-300">
               <QrCode className="h-4 w-4" />
             </div>
-            Get The App
+            Ouvrir L'App
           </button>
 
           {showQr && (
@@ -148,7 +148,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
           </div>
 
           <div className="space-y-2 text-xs sm:text-sm">
-            <p className="text-gray-500">Powered by Bougnat Darts XP Engine</p>
+            <p className="text-gray-500">Propulse par le moteur Bougnat Darts XP</p>
             <button
               onClick={() => setShowChangelog(true)}
               className="font-black text-orange-400 underline decoration-orange-400/50 underline-offset-4 transition-colors hover:text-orange-300"

--- a/views/JoinWithCodeView.tsx
+++ b/views/JoinWithCodeView.tsx
@@ -117,11 +117,11 @@ export const JoinWithCodeView: React.FC<JoinWithCodeViewProps> = ({
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Join Lobby
+                Rejoindre Un Lobby
               </div>
               <div>
                 <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">
@@ -236,7 +236,7 @@ export const JoinWithCodeView: React.FC<JoinWithCodeViewProps> = ({
                           />
                           <div className="truncate text-sm font-black uppercase tracking-[0.14em] text-white">{lookup.hostName}</div>
                           <div className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-[10px] font-black uppercase tracking-[0.16em] text-orange-300">
-                            Host
+                            Hote
                           </div>
                         </div>
                         <div className="mt-2 text-sm text-gray-400">{lookup.title}</div>
@@ -250,7 +250,7 @@ export const JoinWithCodeView: React.FC<JoinWithCodeViewProps> = ({
                       <div className="mt-2 text-lg font-black uppercase tracking-[0.08em] text-white">{lookup.mode}</div>
                     </div>
                     <div className="rounded-[1.4rem] border border-white/8 bg-black/20 p-4">
-                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Players</div>
+                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Joueurs</div>
                       <div className="mt-2 text-lg font-black uppercase tracking-[0.08em] text-white">
                         {lookup.currentPlayers} / {lookup.maxPlayers}
                       </div>
@@ -260,7 +260,7 @@ export const JoinWithCodeView: React.FC<JoinWithCodeViewProps> = ({
                       <div className="mt-2 text-lg font-black uppercase tracking-[0.14em] text-orange-300">{lookup.lobbyCode}</div>
                     </div>
                     <div className="rounded-[1.4rem] border border-white/8 bg-black/20 p-4">
-                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Created</div>
+                      <div className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">Cree</div>
                       <div className="mt-2 text-sm font-bold text-white">{formatDate(lookup.createdAt)}</div>
                     </div>
                   </div>

--- a/views/LobbyView.tsx
+++ b/views/LobbyView.tsx
@@ -106,14 +106,14 @@ export const LobbyView: React.FC<LobbyViewProps> = ({
               onClick={onOpenHistory}
               className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-[11px] font-black uppercase tracking-[0.22em] text-gray-300 transition-all hover:border-orange-400/30 hover:bg-white/[0.07] hover:text-white"
             >
-              History
+              Historique
             </button>
 
             <button
               onClick={onOpenStats}
               className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-[11px] font-black uppercase tracking-[0.22em] text-gray-300 transition-all hover:border-orange-400/30 hover:bg-white/[0.07] hover:text-white"
             >
-              My Stats
+              Mes Stats
             </button>
           </div>
 
@@ -161,11 +161,11 @@ export const LobbyView: React.FC<LobbyViewProps> = ({
 
           <div className="rounded-[1.6rem] border border-white/8 bg-black/20 px-5 py-4 text-center text-sm text-gray-400">
             <span className="font-black text-orange-300">Suggestion:</span>{' '}
-            The fastest route back to competition is to relaunch a{' '}
+            Le chemin le plus rapide pour revenir a la competition est de relancer un{' '}
             <button onClick={onResumeGame} className="font-black text-white underline decoration-orange-400/40 underline-offset-4">
-              501 set
+              set de 501
             </button>{' '}
-            or open arena setup to challenge a friend in Cricket.
+            ou d'ouvrir l'arena pour defier un ami en Cricket.
           </div>
         </div>
         )}

--- a/views/MatchView.tsx
+++ b/views/MatchView.tsx
@@ -265,7 +265,7 @@ export const MatchView: React.FC<MatchViewProps> = ({
       </div>
 
       {/* Control Area */}
-      <div className="relative z-30 flex h-[29svh] min-h-[236px] max-h-[360px] shrink-0 flex-col border-t border-gray-800 bg-gray-900 pb-safe shadow-[0_-5px_20px_rgba(0,0,0,0.5)] sm:h-[30svh] sm:min-h-[248px] md:h-[31svh] lg:h-[32svh]">
+      <div className="relative z-30 flex h-[clamp(14rem,28svh,22rem)] shrink-0 flex-col border-t border-gray-800 bg-gray-900 pb-safe shadow-[0_-5px_20px_rgba(0,0,0,0.5)] sm:h-[clamp(15rem,29svh,23rem)] md:h-[clamp(16rem,30svh,24rem)]">
          
          {/* Live Input Bar */}
          <div className="flex h-11 items-center justify-between border-b border-gray-800 bg-black/60 px-3 backdrop-blur-sm sm:h-12 sm:px-4 md:h-14">
@@ -312,17 +312,17 @@ export const MatchView: React.FC<MatchViewProps> = ({
                   onQuickAction={handleQuickScore}
                />
             </div>
-            <div className="flex w-[72px] flex-col gap-1.5 sm:w-20 sm:gap-2 md:w-24">
+            <div className="flex w-[68px] flex-col gap-1.5 sm:w-20 sm:gap-2 md:w-24">
                 <Button 
                     variant="secondary" 
-                    className="h-1/3 min-h-10 text-[10px] font-black leading-tight bg-gray-800 border-gray-700 px-1 text-cyan-500 shadow-md hover:border-cyan-500/50 hover:bg-cyan-900 hover:text-white sm:min-h-11 sm:text-[11px] md:min-h-12 md:text-sm" 
+                    className="h-1/3 min-h-0 px-1 py-1 text-[9px] font-black leading-tight bg-gray-800 border-gray-700 text-cyan-500 shadow-md hover:border-cyan-500/50 hover:bg-cyan-900 hover:text-white sm:text-[11px] md:text-sm" 
                     onClick={handleRemainingSubmit}
                     title="Entrer le score qu'il reste"
                 >
                     RESTE
                 </Button>
                 <Button 
-                    className="flex-1 min-h-14 text-xl font-black shadow-lg shadow-orange-900/30 sm:min-h-16 sm:text-2xl md:text-3xl" 
+                    className="flex-1 min-h-0 px-1 py-1 text-lg font-black shadow-lg shadow-orange-900/30 sm:text-2xl md:text-3xl" 
                     onClick={handleSubmitScore}
                 >
                     OK

--- a/views/MyStatsView.tsx
+++ b/views/MyStatsView.tsx
@@ -96,18 +96,18 @@ export const MyStatsView: React.FC<MyStatsViewProps> = ({ user, onBack, onOpenPr
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Performance Overview
+                Vue D'Ensemble
               </div>
               <div>
                 <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">
-                  My Stats
+                  Mes Stats
                 </h1>
                 <p className="mt-2 max-w-2xl text-sm text-gray-400 sm:text-base">
-                  Track your scoring pace, closing power and overall results across every recorded match.
+                  Suis ton rythme de score, ta qualite de finish et tes resultats sur tous les matchs enregistres.
                 </p>
               </div>
             </div>
@@ -125,35 +125,35 @@ export const MyStatsView: React.FC<MyStatsViewProps> = ({ user, onBack, onOpenPr
               <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-2xl border border-orange-500/20 bg-orange-500/10 text-3xl">
                 📊
               </div>
-              <h2 className="text-2xl font-black uppercase tracking-[-0.04em] text-white">No statistics yet</h2>
+              <h2 className="text-2xl font-black uppercase tracking-[-0.04em] text-white">Aucune statistique pour le moment</h2>
               <p className="mt-3 text-sm text-gray-400">
-                Finish a match and your scoring profile will start building automatically.
+                Termine un match et ton profil de score commencera a se construire automatiquement.
               </p>
             </div>
           </div>
         ) : (
           <div className="space-y-6 pb-8">
             <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <StatCard label="Global Average" value={stats.globalAvg} accent="orange" large />
-              <StatCard label="Win Rate" value={`${winRate}%`} accent="green" large />
-              <StatCard label="Matches Played" value={String(stats.totalMatches)} accent="white" />
-              <StatCard label="Victories" value={String(stats.wins)} accent="orange" />
+              <StatCard label="Moyenne Generale" value={stats.globalAvg} accent="orange" large />
+              <StatCard label="Taux De Victoire" value={`${winRate}%`} accent="green" large />
+              <StatCard label="Matchs Joues" value={String(stats.totalMatches)} accent="white" />
+              <StatCard label="Victoires" value={String(stats.wins)} accent="orange" />
             </section>
 
             <section className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
               <div className="rounded-[2rem] border border-white/10 bg-[#0d131d]/88 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-xl">
-                <div className="mb-5 text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Best Finishing Form</div>
+                <div className="mb-5 text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Meilleur Finish</div>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <HighlightCard label="Highest Checkout" value={String(stats.highestCheckout)} suffix="" />
-                  <HighlightCard label="Best Leg" value={stats.bestLeg ? String(stats.bestLeg) : '-'} suffix="darts" />
+                  <HighlightCard label="Plus Haut Checkout" value={String(stats.highestCheckout)} suffix="" />
+                  <HighlightCard label="Meilleure Manche" value={stats.bestLeg ? String(stats.bestLeg) : '-'} suffix="flechettes" />
                 </div>
               </div>
 
               <div className="rounded-[2rem] border border-white/10 bg-[#0d131d]/88 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-xl">
-                <div className="mb-5 text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Session Split</div>
+                <div className="mb-5 text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Repartition</div>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <MiniMetric label="Wins" value={String(stats.wins)} tone="emerald" />
-                  <MiniMetric label="Losses" value={String(stats.losses)} tone="slate" />
+                  <MiniMetric label="Victoires" value={String(stats.wins)} tone="emerald" />
+                  <MiniMetric label="Defaites" value={String(stats.losses)} tone="slate" />
                 </div>
                 <div className="mt-5 h-3 overflow-hidden rounded-full bg-white/10">
                   <div className="h-full rounded-full bg-gradient-to-r from-orange-500 via-red-500 to-orange-400" style={{ width: `${winRate}%` }} />
@@ -164,10 +164,10 @@ export const MyStatsView: React.FC<MyStatsViewProps> = ({ user, onBack, onOpenPr
             <section className="rounded-[2rem] border border-white/10 bg-[#0d131d]/88 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-xl">
               <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
                 <div>
-                  <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Scoring Heatmap</div>
-                  <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">High-scoring visits</h2>
+                  <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Carte Des Scores</div>
+                  <h2 className="mt-2 text-2xl font-black uppercase tracking-[-0.04em] text-white">Grosses Volees</h2>
                 </div>
-                <p className="text-sm text-gray-400">A quick view of your heavy scoring production.</p>
+                <p className="text-sm text-gray-400">Une vue rapide de tes grosses productions de score.</p>
               </div>
               <div className="grid gap-4 md:grid-cols-3">
                 <HeatCard label="180s" value={String(stats.total180s)} accent="from-red-500 to-orange-500" />

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -89,16 +89,16 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onOpenPr
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
             <Button variant="ghost" onClick={onBack} size="sm">
-              ← Back
+              ← Retour
             </Button>
             <div className="space-y-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.28em] text-orange-200">
-                Player Profile
+                Profil Joueur
               </div>
               <div>
-                <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">My Account</h1>
+                <h1 className="text-3xl font-black uppercase tracking-[-0.05em] text-white sm:text-4xl">Mon Compte</h1>
                 <p className="mt-2 max-w-2xl text-sm text-gray-400 sm:text-base">
-                  Tune your player identity, keep your handle clean and choose the flag shown across the arena menus.
+                  Regle ton identite joueur, soigne ton pseudo et choisis le drapeau affiche dans les menus de l'arena.
                 </p>
               </div>
             </div>
@@ -108,7 +108,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onOpenPr
 
         <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
           <aside className="rounded-[2rem] border border-white/10 bg-[#0d131d]/88 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-xl">
-            <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Identity Preview</div>
+            <div className="text-[11px] font-black uppercase tracking-[0.28em] text-gray-500">Apercu De L'Identite</div>
             <div className="mt-6 flex flex-col items-center text-center">
               <div className="relative group">
                 <div className="h-36 w-36 overflow-hidden rounded-[2rem] border border-orange-500/20 bg-black/25 shadow-[0_0_24px_rgba(249,115,22,0.14)] transition-transform duration-300 group-hover:scale-[1.02]">
@@ -117,14 +117,14 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onOpenPr
                 <button
                   onClick={handleShuffleAvatar}
                   className="absolute -bottom-2 -right-2 rounded-2xl border border-orange-400/30 bg-orange-500 px-3 py-3 text-white shadow-[0_10px_24px_rgba(249,115,22,0.25)] transition-colors hover:bg-orange-400"
-                  title="Randomize Avatar"
+                  title="Aleatoire Avatar"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                   </svg>
                 </button>
               </div>
-              <div className="mt-6 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Arena Identity</div>
+              <div className="mt-6 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Identite Arena</div>
               <div className="mt-3 flex items-center gap-3">
                 <img
                   src={countryFlagUrl}


### PR DESCRIPTION
## Summary

This PR promotes the latest hotfix from `release/1.0.0-beta.3` into `preprod`.

It includes three main improvements:
- responsive fixes for in-game keypads on laptop-height screens
- Capital mode rule fixes
- a broad French localization pass across the core UI

## Included changes

### Responsive gameplay fixes
- compact X01, Cricket, and Capital keypads for smaller laptop screens
- replace rigid keypad height constraints with more adaptive layouts
- reduce oversized button minimum heights to prevent truncation
- improve vertical flexibility in the main gameplay views

### Capital mode fixes
- add the missing `17 points ou moins` contract between `57` and `Couleur`
- resolve the `57` contract immediately as soon as 57 is reached
- allow instant success on first dart for `57` (example: `T19`)
- end the `57` turn as soon as the target is reached or cannot be recovered

### French localization
- translate key entry points: Home, Auth, Dashboard, Lobby, History, My Stats, Profile
- translate lobby/social flows: quick actions, recent matches, friends, invites, create/join lobby
- translate lobby-derived labels, mock data, ranks, challenges, and fallback messages
- reduce English/French mixing in the visible UI

## Validation
- `npm run typecheck`

## Notes
- hotfix already applied and pushed on `release/1.0.0-beta.3`
- this PR is the required path to promote the fix into `preprod` because direct pushes to `preprod` are blocked by repository rules
