### PR TITLE
hotfix: stabilize preprod deploy and enable vercel telemetry

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -64,9 +64,20 @@ jobs:
       - name: Deploy prebuilt artifacts to Vercel
         id: deploy
         run: |
-          url="$(vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})"
-          echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preprod deployment URL: $url"
+          for attempt in 1 2 3; do
+            echo "Deployment attempt ${attempt}/3"
+            if url="$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"; then
+              echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
+              echo "Preprod deployment URL: $url"
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Vercel deploy failed, retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+          echo "Vercel deploy failed after 3 attempts." >&2
+          exit 1
 
       - name: Deployment summary
         run: |

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,8 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import { App } from './App';
 
 // Service Worker Registration for PWA
@@ -25,5 +27,7 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <App />
+    <Analytics />
+    <SpeedInsights />
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "2",
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^0.577.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -1847,6 +1849,86 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "2",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "lucide-react": "^0.577.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
## Summary

This hotfix updates the preprod Vercel deployment flow and enables Vercel telemetry in the app.

## Changes

- remove `--archive=tgz` from the preprod Vercel deploy step
- add a 3-attempt retry loop around `vercel deploy --prebuilt --prod`
- add `@vercel/analytics`
- add `@vercel/speed-insights`
- mount `<Analytics />` and `<SpeedInsights />` in the React entrypoint
- keep the lockfile compatible with the public npm registry for GitHub Actions / Vercel builds

## Why

- preprod deploys were failing during the final Vercel upload step with an internal error
- we want a more resilient deploy pipeline for preprod
- we also want Vercel Analytics and Speed Insights enabled on the deployed app

## Validation

- workflow YAML validated
- `npm run typecheck`
- `npm run build`

## Notes

- target branch: `preprod`
- compare branch: `hotfix/beta3-vercel-deploy`
