### PR TITLE
Harden installs and remove birth date from profile

### DIFF
--- a/.github/workflows/dependency-watch.yml
+++ b/.github/workflows/dependency-watch.yml
@@ -33,7 +33,32 @@ jobs:
       - name: Install dependencies
         env:
           NODE_ENV: development
-        run: npm ci --include=dev --no-audit --no-fund
+        run: |
+          install_ok=1
+          npm ci --include=dev --no-audit --no-fund || install_ok=0
+          node <<'EOF' || install_ok=0
+          const fs = require('fs');
+          const checks = ['vite', 'vitest', 'eslint'];
+          const missing = checks.filter((name) => !fs.existsSync(`node_modules/${name}/package.json`));
+          if (missing.length > 0) {
+            console.log(`Missing after npm ci: ${missing.join(', ')}`);
+            process.exit(1);
+          }
+          EOF
+          if [ "$install_ok" -ne 1 ]; then
+            rm -rf node_modules
+            corepack enable
+            corepack prepare pnpm@10.18.3 --activate
+            pnpm install --no-frozen-lockfile --config.node-linker=hoisted
+          fi
+          node <<'EOF'
+          const fs = require('fs');
+          const checks = ['vite', 'vitest', 'eslint'];
+          const missing = checks.filter((name) => !fs.existsSync(`node_modules/${name}/package.json`));
+          if (missing.length > 0) {
+            throw new Error(`Missing after fallback install: ${missing.join(', ')}`);
+          }
+          EOF
 
       - name: Generate outdated report
         run: |

--- a/.github/workflows/promote-preprod.yml
+++ b/.github/workflows/promote-preprod.yml
@@ -157,19 +157,21 @@ jobs:
           git fetch origin preprod || true
           git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/preprod --force
 
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+      - name: Prepare pnpm for Vercel CLI
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.3 --activate
 
       - name: Pull Vercel project settings
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Vercel artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy preprod artifacts
         id: deploy
         run: |
-          url="$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
+          url="$(pnpm dlx vercel@latest deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
           echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Deployment summary

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -157,19 +157,21 @@ jobs:
           git fetch origin production || true
           git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/production --force
 
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+      - name: Prepare pnpm for Vercel CLI
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.3 --activate
 
       - name: Pull Vercel project settings
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Vercel artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy production artifacts
         id: deploy
         run: |
-          url="$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
+          url="$(pnpm dlx vercel@latest deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
           echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Deployment summary

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -3,7 +3,9 @@ FROM node:22-bookworm-slim
 WORKDIR /workspace
 
 COPY package*.json ./
-RUN npm ci
+RUN corepack enable \
+  && corepack prepare pnpm@10.18.3 --activate \
+  && pnpm install --no-frozen-lockfile --config.node-linker=hoisted
 
 COPY . .
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "npm run build",
-  "installCommand": "npm ci",
+  "installCommand": "corepack enable && corepack prepare pnpm@10.18.3 --activate && pnpm install --no-frozen-lockfile --config.node-linker=hoisted",
   "outputDirectory": "dist",
   "headers": [
     {

--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -26,7 +26,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
   const [username, setUsername] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [birthDate, setBirthDate] = useState('');
   const [clubName, setClubName] = useState('');
   const [committeeName, setCommitteeName] = useState('');
   const [leagueName, setLeagueName] = useState('');
@@ -37,62 +36,12 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [msg, setMsg] = useState<{ type: 'success' | 'error', text: string } | null>(null);
 
-  const formatBirthDateForDisplay = (value: string | null | undefined) => {
-    const normalized = String(value || '').trim();
-    if (!normalized) return '';
-
-    const isoMatch = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-    if (isoMatch) {
-      const [, year, month, day] = isoMatch;
-      return `${day}/${month}/${year}`;
-    }
-
-    return normalized;
-  };
-
-  const normalizeBirthDateInput = (value: string) => {
-    const digits = value.replace(/\D/g, '').slice(0, 8);
-
-    if (digits.length <= 2) return digits;
-    if (digits.length <= 4) return `${digits.slice(0, 2)}/${digits.slice(2)}`;
-    return `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
-  };
-
-  const formatBirthDateForStorage = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-
-    const match = trimmed.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-    if (!match) {
-      throw new Error('La date de naissance doit etre au format JJ/MM/AAAA.');
-    }
-
-    const [, day, month, year] = match;
-    const isoDate = `${year}-${month}-${day}`;
-    const parsed = new Date(`${isoDate}T00:00:00Z`);
-
-    if (Number.isNaN(parsed.getTime())) {
-      throw new Error('La date de naissance saisie est invalide.');
-    }
-
-    if (
-      parsed.getUTCFullYear() !== Number(year) ||
-      parsed.getUTCMonth() + 1 !== Number(month) ||
-      parsed.getUTCDate() !== Number(day)
-    ) {
-      throw new Error('La date de naissance saisie est invalide.');
-    }
-
-    return isoDate;
-  };
-
   // Load initial data
   useEffect(() => {
     if (!user?.id) {
       setUsername('');
       setFirstName('');
       setLastName('');
-      setBirthDate('');
       setClubName('');
       setCommitteeName('');
       setLeagueName('');
@@ -110,14 +59,13 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
       const fallbackAvatarSeed = getAvatarId(meta.avatar_seed || meta.username || fallbackUsername || 'player');
       const fallbackFirstName = String(meta.first_name || '');
       const fallbackLastName = String(meta.last_name || '');
-      const fallbackBirthDate = formatBirthDateForDisplay(String(meta.birth_date || ''));
       const fallbackClubName = String(meta.club_name || '');
       const fallbackCommitteeName = String(meta.committee_name || '');
       const fallbackLeagueName = String(meta.league_name || '');
 
       const { data: profileRow, error } = await supabase
         .from('player_profiles')
-        .select('username, country_code, avatar_seed, first_name, last_name, birth_date, club_name, committee_name, league_name')
+        .select('username, country_code, avatar_seed, first_name, last_name, club_name, committee_name, league_name')
         .eq('user_id', user.id)
         .maybeSingle();
 
@@ -132,7 +80,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
       const nextAvatarSeed = getAvatarId(profileRow?.avatar_seed || fallbackAvatarSeed);
       const nextFirstName = String(profileRow?.first_name || fallbackFirstName);
       const nextLastName = String(profileRow?.last_name || fallbackLastName);
-      const nextBirthDate = formatBirthDateForDisplay(String(profileRow?.birth_date || fallbackBirthDate));
       const nextClubName = String(profileRow?.club_name || fallbackClubName);
       const nextCommitteeName = String(profileRow?.committee_name || fallbackCommitteeName);
       const nextLeagueName = String(profileRow?.league_name || fallbackLeagueName);
@@ -140,7 +87,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
       setUsername(nextUsername);
       setFirstName(nextFirstName);
       setLastName(nextLastName);
-      setBirthDate(nextBirthDate);
       setClubName(nextClubName);
       setCommitteeName(nextCommitteeName);
       setLeagueName(nextLeagueName);
@@ -166,14 +112,12 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
       if (!isValidCountryCode(countryCode)) throw new Error('Merci de selectionner un pays valide.');
 
       const normalizedUsername = canonicalizeUsername(username);
-      const normalizedBirthDate = formatBirthDateForStorage(birthDate);
       const profileMetadata = {
         username: normalizedUsername,
         country_code: countryCode,
         avatar_seed: avatarSeed,
         first_name: firstName.trim(),
         last_name: lastName.trim(),
-        birth_date: normalizedBirthDate,
         club_name: clubName.trim(),
         committee_name: committeeName.trim(),
         league_name: leagueName.trim(),
@@ -204,7 +148,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
           avatar_seed: avatarSeed,
           first_name: firstName.trim() || null,
           last_name: lastName.trim() || null,
-          birth_date: normalizedBirthDate,
           club_name: clubName.trim() || null,
           committee_name: committeeName.trim() || null,
           league_name: leagueName.trim() || null,
@@ -216,7 +159,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
       setUsername(nextUser.user_metadata?.username || '');
       setFirstName(nextUser.user_metadata?.first_name || '');
       setLastName(nextUser.user_metadata?.last_name || '');
-      setBirthDate(formatBirthDateForDisplay(nextUser.user_metadata?.birth_date || ''));
       setClubName(nextUser.user_metadata?.club_name || '');
       setCommitteeName(nextUser.user_metadata?.committee_name || '');
       setLeagueName(nextUser.user_metadata?.league_name || '');
@@ -384,19 +326,6 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, onBack, onLogout
                       placeholder="Ton nom"
                     />
                   </div>
-                </div>
-
-                <div>
-                  <label className="mb-2 block text-[10px] font-black uppercase tracking-[0.22em] text-gray-500">Date De Naissance</label>
-                  <input
-                    type="text"
-                    value={birthDate}
-                    onChange={(e) => setBirthDate(normalizeBirthDateInput(e.target.value))}
-                    inputMode="numeric"
-                    maxLength={10}
-                    placeholder="JJ/MM/AAAA"
-                    className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-4 text-base font-semibold text-white outline-none transition-all placeholder:text-gray-600 focus:border-orange-400/40 focus:bg-black/30"
-                  />
                 </div>
 
                 <div>


### PR DESCRIPTION
## Summary

This PR aligns `main` with the latest hardening already applied on `develop` and `release/1.0.0-beta.3`.

## Changes

- harden install paths used by deployment-related flows
- switch Vercel build/install flow to `corepack + pnpm`
- add resilient dependency install fallback in `dependency-watch`
- update the app Docker image install step to avoid fragile `npm ci`
- remove the birth date field from the player profile UI and form handling

## Why

We were still exposed to intermittent install failures during deploy/promote flows, especially when Vercel or CI invoked `npm ci` directly. This change reduces those failure modes and keeps deployment behavior aligned with the hardened CI strategy already in place.

It also removes the birthday field from the player profile form, as requested.

## Validation

- `npm run typecheck`
- local validation of `corepack -> pnpm -> pnpm dlx vercel`
