### PR TITLE
Restore deployment env after local smoke tests

### DIFF
--- a/.github/workflows/promote-preprod.yml
+++ b/.github/workflows/promote-preprod.yml
@@ -140,6 +140,20 @@ jobs:
         if: always()
         run: npm run supabase:stop
 
+      - name: Restore preprod deployment env
+        run: |
+          {
+            echo "VITE_APP_ENV=${{ vars.VITE_APP_ENV }}"
+            echo "VITE_APP_NAME=${{ vars.VITE_APP_NAME }}"
+            echo "VITE_APP_VERSION=${GITHUB_SHA}"
+            echo "VITE_APP_URL=${{ vars.VITE_APP_URL }}"
+            echo "VITE_SUPABASE_URL=${{ vars.VITE_SUPABASE_URL }}"
+            echo "VITE_SUPABASE_ANON_KEY=${{ secrets.VITE_SUPABASE_ANON_KEY }}"
+            echo "VITE_ENABLE_ANALYTICS=${{ vars.VITE_ENABLE_ANALYTICS }}"
+            echo "VITE_ENABLE_BETA_BADGE=${{ vars.VITE_ENABLE_BETA_BADGE }}"
+            echo "VITE_LOG_LEVEL=${{ vars.VITE_LOG_LEVEL }}"
+          } >> "$GITHUB_ENV"
+
       - name: Sync preprod mirror branch
         run: |
           git fetch origin preprod || true

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -140,6 +140,20 @@ jobs:
         if: always()
         run: npm run supabase:stop
 
+      - name: Restore production deployment env
+        run: |
+          {
+            echo "VITE_APP_ENV=${{ vars.VITE_APP_ENV }}"
+            echo "VITE_APP_NAME=${{ vars.VITE_APP_NAME }}"
+            echo "VITE_APP_VERSION=${GITHUB_SHA}"
+            echo "VITE_APP_URL=${{ vars.VITE_APP_URL }}"
+            echo "VITE_SUPABASE_URL=${{ vars.VITE_SUPABASE_URL }}"
+            echo "VITE_SUPABASE_ANON_KEY=${{ secrets.VITE_SUPABASE_ANON_KEY }}"
+            echo "VITE_ENABLE_ANALYTICS=${{ vars.VITE_ENABLE_ANALYTICS }}"
+            echo "VITE_ENABLE_BETA_BADGE=${{ vars.VITE_ENABLE_BETA_BADGE }}"
+            echo "VITE_LOG_LEVEL=${{ vars.VITE_LOG_LEVEL }}"
+          } >> "$GITHUB_ENV"
+
       - name: Sync production mirror branch
         run: |
           git fetch origin production || true


### PR DESCRIPTION
## Summary
- restore preprod environment variables after local smoke-test overrides
- restore production environment variables after local smoke-test overrides
- ensure `vercel build --prod` uses the real deployment auth/app settings

## Why
The promotion workflows overwrite `VITE_APP_URL`, `VITE_SUPABASE_URL`, and related variables for local smoke validation (`127.0.0.1` / local Supabase), but did not restore them before the Vercel production build.

That can produce a deployed bundle with incorrect auth callback URLs and environment settings in preprod/production.

## Validation
- workflow diff reviewed
- fix is scoped to CI/CD env restoration before Vercel build/deploy
