### PR TITLE
Release v1.0.2 — Stabilisation du moteur de scoring open source

### DIFF
--- a/.github/workflows/promote-preprod.yml
+++ b/.github/workflows/promote-preprod.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           required-packages: "vite"
 
-      - name: Prepare pnpm for Vercel CLI
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.18.3 --activate
-
       - name: Validate preprod environment
         run: npm run preprod:check
 
@@ -75,18 +70,18 @@ jobs:
           fi
 
       - name: Validate Vercel access
-        run: pnpm dlx vercel@latest whoami --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@latest whoami --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Pull Vercel project settings
-        run: pnpm dlx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Vercel artifacts
-        run: pnpm dlx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy preprod artifacts
         id: deploy
         run: |
-          url="$(pnpm dlx vercel@latest deploy --prebuilt --prod \
+          url="$(npx --yes vercel@latest deploy --prebuilt --prod \
             --env=DEEPGRAM_PROJECT_ID=${DEEPGRAM_PROJECT_ID} \
             --env=DEEPGRAM_API_KEY=${DEEPGRAM_API_KEY} \
             --token=${{ secrets.VERCEL_TOKEN }})"

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -158,21 +158,16 @@ jobs:
           git fetch origin production || true
           git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/production --force
 
-      - name: Prepare pnpm for Vercel CLI
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.18.3 --activate
-
       - name: Pull Vercel project settings
-        run: pnpm dlx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Vercel artifacts
-        run: pnpm dlx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy production artifacts
         id: deploy
         run: |
-          url="$(pnpm dlx vercel@latest deploy --prebuilt --prod \
+          url="$(npx --yes vercel@latest deploy --prebuilt --prod \
             --env=DEEPGRAM_API_KEY=${DEEPGRAM_API_KEY} \
             --env=DEEPGRAM_PROJECT_ID=${DEEPGRAM_PROJECT_ID} \
             --token=${{ secrets.VERCEL_TOKEN }})"

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ pnpm-debug.log*
 # Vercel
 .vercel/
 
-# Supabase local state
+# Ancien outillage Supabase retire du runtime open source.
+# Les references trackees ont ete nettoyees; ces patterns restent ignores
+# uniquement pour eviter le bruit local lors d un poste ayant conserve cet outillage.
 .supabase/
 supabase/.temp/
 supabase/.branches/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+replace-registry-host=always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,27 @@
 - documenter les changements structurants dans les specs et les docs d architecture
 - ne pas reintroduire de dependance runtime a un backend metier dans le perimetre supporte
 
+## Frontiere open source `v1.0.2`
+
+Les contributions attendues doivent renforcer ou clarifier :
+
+- scoring
+- jeux supportes
+- voice scoring optionnel
+- persistance locale
+- reprise locale
+- experience offline-first
+- traçabilite spec → code → tests → issues
+
+Les contributions ne doivent pas reintroduire dans ce repo :
+
+- backend metier
+- authentification metier avancee
+- profils distants persistants
+- statistiques cloud consolidees
+- logique tournoi proprietaire
+- dependance runtime obligatoire a `Bougnat_Darts_Tournaments`
+
 ## Verification minimale
 
 Avant une pull request :
@@ -29,7 +50,7 @@ npm run test:e2e
 
 ## Orientation produit
 
-Les contributions attendues pour `v1.0.1+` concernent en priorite :
+Les contributions attendues pour `v1.0.2+` concernent en priorite :
 
 - scoring
 - jeux

--- a/README.md
+++ b/README.md
@@ -52,6 +52,40 @@ Une base simple et efficace pour structurer le scoring, accueillir les joueurs e
 
 Le scorage manuel reste toujours disponible. L'assistance vocale peut accompagner le X01 quand elle est activee, mais le jeu ne depend jamais du micro.
 
+## ✅ Statut de la base `v1.0.2`
+
+`Bougnat_darts_counter` est publie comme une base open source stable centree sur :
+
+- le moteur de scoring
+- les jeux de flechettes supportes
+- le voice scoring `X01` optionnel
+- les sessions locales
+- la reprise locale
+- l experience offline-first
+
+Le runtime supporte en `v1.0.2` ne depend d aucun backend metier obligatoire.
+
+## 🚫 Hors perimetre explicite
+
+Ce repo ne contient pas :
+
+- authentification metier avancee
+- profils distants persistés
+- statistiques cloud consolidees
+- logique tournoi
+- persistance backend metier
+- couplage proprietaire obligatoire avec `Bougnat_Darts_Tournaments`
+
+Les integrations externes eventuelles doivent rester contractuelles et optionnelles, sans casser le gameplay local.
+
+## 🔌 Separation avec `Bougnat_Darts_Tournaments`
+
+`Bougnat_darts_counter` porte le scorage open source et l experience de jeu locale.
+
+`Bougnat_Darts_Tournaments` est le systeme maitre metier reserve a l orchestration tournoi, aux donnees proprietaires et aux integrations backend explicites.
+
+La frontiere `v1.0.2` impose qu aucune logique proprietaire ne soit necessaire pour lancer, scorer, corriger, annuler, terminer et reprendre localement une partie.
+
 ## ❤️ Pourquoi les joueurs l'aiment
 
 **⚡ Ca demarre vite**
@@ -100,10 +134,12 @@ Chaque retour terrain compte.
 ## 📚 Infos utiles
 
 - [Guide technique et developpement](docs/technical.md)
+- [Architecture cible](docs/architecture.md)
 - [Perimetre produit](docs/product-scope.md)
 - [Securite](SECURITY.md)
 - [Contribuer](CONTRIBUTING.md)
-- [Notes de version](docs/release/v1.0.1.md)
+- [Notes de version v1.0.2](docs/release/v1.0.2.md)
+- [Coverage map v1.0.2](docs/release/v1.0.2-coverage-map.md)
 
 ## 📄 Licence
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ Le repo porte le moteur de scorage, les modes de jeu, les sessions locales et le
 
 Il ne porte pas la source de vérité métier pour l organisation de tournoi, les profils distants ou les statistiques cloud.
 
+La base `v1.0.2` est considerée stable pour un usage open source centre sur le scorage local. Les chantiers restants relevent de clarifications ou de decoupes internes, pas d un elargissement de perimetre.
+
 ## Core Principles
 
 - gameplay first: aucune évolution ne doit dégrader les flux de scoring supportés
@@ -144,6 +146,8 @@ The supported open source repo does not own:
 - cloud statistics consolidation
 - tournament orchestration
 - proprietary business persistence
+
+En pratique, la seule integration reseau supportee dans le runtime `v1.0.2` reste le voice scoring optionnel via Deepgram, avec fallback manuel obligatoire et sans dependance gameplay au reseau.
 
 ## Decision v1.0.2
 

--- a/docs/audit-security-vercel-performance-2026-04-24.md
+++ b/docs/audit-security-vercel-performance-2026-04-24.md
@@ -13,7 +13,7 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 | `api/deepgram/token.ts` | Haute | Endpoint vocal exposable a l'abus, CORS implicite, erreurs fournisseur renvoyees au navigateur | Corrige: CORS strict, validation JSON, rate limit best-effort, no-store, headers de securite, erreurs client generiques |
 | `vite.config.ts` | Moyenne | Le proxy local Deepgram exposait aussi des details fournisseur | Corrige: reponses locales alignees, pas de details sensibles client, headers no-store/nosniff |
 | `scripts/deployment-check.mjs` | Haute | Risque de secret rendu public via variable `VITE_*` sur Vercel | Corrige: detection bloquante des noms publics sensibles (`SECRET`, `TOKEN`, `API_KEY`, etc.) |
-| `vercel.json` | Moyenne | Build non reproductible avec `pnpm --no-frozen-lockfile` mal aligne sur `package-lock.json` | Corrige: `npm ci` |
+| `vercel.json` | Moyenne | Build Vercel sensible aux differences d'outil d'installation | Corrige: installation npm explicite et package manager declare |
 | `package-lock.json` | Moyenne | `npm audit` signalait `brace-expansion` en dependance dev | Corrige: `npm audit fix`, audit a 0 vulnerabilite |
 | `App.tsx`, `index.tsx` | Basse | Bundle initial et logs runtime trop bavards | Corrige: lazy loading des ecrans setup/match, loader plus sobre, logs SW limites au debug |
 | `views/MatchView.tsx`, `views/SetupView.tsx` | Basse | Composants volumineux | Action prudente: chargement a la demande. Extraction interne a planifier plus tard si evolution fonctionnelle |
@@ -28,7 +28,7 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 - CORS: aucune wildcard; l'origine doit etre l'origine de la requete Vercel ou `VITE_APP_URL`.
 - Abuse: rate limiting memoire best-effort par IP sur Edge. Pour une forte exposition publique, passer a une solution partagee type Vercel KV/Upstash.
 - Logs: les erreurs fournisseur sont journalisees cote serveur sans renvoyer de detail au navigateur; les logs service worker passent en debug.
-- Build output: build Vite valide, secrets non injectes via `VITE_*`, installation Vercel reproductible par `npm ci`.
+- Build output: build Vite valide, secrets non injectes via `VITE_*`, installation Vercel alignee sur npm via configuration explicite.
 
 ## Dette et risques residuels
 
@@ -41,7 +41,7 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 - Durcissement serverless Deepgram et tests unitaires API.
 - Blocage des variables publiques sensibles au deploiement.
 - Correction `npm audit`.
-- Build Vercel aligne sur `package-lock.json`.
+- Build Vercel aligne sur npm avec configuration explicite.
 - Lazy loading des ecrans de scorage et setup.
 - Logs runtime reduits hors debug.
 

--- a/docs/product-scope.md
+++ b/docs/product-scope.md
@@ -35,6 +35,8 @@
 
 Le repo est publie comme une application open source de scoring stable en `v1.0.2`.
 
+Cette release stable couvre uniquement le gameplay local, le scoring, les jeux supportes, le voice scoring optionnel, les sessions locales et la logique offline-first.
+
 Le voice scoring reste un module optionnel: l application doit rester jouable en scorage manuel si Deepgram est indisponible.
 
 `VITE_TOURNAMENT_API_URL` est un point d integration optionnel et documenté. Aucun gameplay local n en depend.

--- a/docs/release/v1.0.2-coverage-map.md
+++ b/docs/release/v1.0.2-coverage-map.md
@@ -1,52 +1,85 @@
 # Coverage Map v1.0.2
 
-## Légende
+Format canonique: `Spec -> Code -> Tests -> Issues -> Status`
 
-| Symbole | Signification |
-|---|---|
-| ✅ | Couvert — code + tests |
-| 🟡 | Partiel — code présent, couverture test limitée |
-| ❌ | Non couvert |
+## Zones couvertes
 
----
+- `spec:counter/scoring-access-modes`
+	- Code: `src/app/appShell.ts`, `src/application/scoring/`, `src/domain/`
+	- Tests: `tests/unit/app/appShell.test.ts`, `tests/unit/x01/*.test.ts`, `tests/unit/gameLogic.test.ts`
+	- Issues: `#70`
+	- Status: `couvert`
 
-## Spec → Code → Tests → Statut
+- `spec:counter/offline-scoring-terminal-foundation`
+	- Code: `src/application/scoring/matchLifecycle.ts`, `src/infrastructure/local/IndexedDBSessionRepository.ts`, `src/features/game-setup/setupModel.ts`, `src/features/game-setup/setupPresentation.ts`
+	- Tests: `tests/unit/application/matchLifecycle.test.ts`, `tests/unit/application/indexedDbSessionRepository.test.ts`, `tests/unit/gameSetup/setupModel.test.ts`
+	- Issues: `#71`
+	- Status: `couvert`
 
-| Spec | Slug | Modules clés | Tests clés | Statut |
-|---|---|---|---|---|
-| 001 | scoring-access-modes | `src/app/appShell.ts`, `src/application/scoring/` | `tests/unit/app/appShell.test.ts` | ✅ |
-| 002 | offline-scoring-terminal-foundation | `src/features/game-setup/setupModel.ts`, `setupPresentation.ts` | `tests/unit/gameSetup/setupModel.test.ts` | ✅ |
-| 003 | voice-scoring-reliability | `api/deepgram/`, `src/lib/deepgramToken.ts` | `tests/unit/lib/deepgramToken.test.ts`, `tests/unit/api/deepgramTokenRoute.test.ts` | ✅ |
-| 004 | release-v1.0.1-stabilization | CI complet, `scripts/guard-clean-codebase.sh` | CI pipeline | ✅ |
-| 005 | ui-scoreboard-layout-consistency | `views/MatchView.tsx`, Tailwind layout | `tests/e2e/gameplay-entry.smoke.spec.ts` | 🟡 |
-| 006 | voice-token-provisioning-hardening | `api/deepgram/token.ts`, `src/lib/env.ts` | `tests/unit/api/deepgramTokenRoute.test.ts` | ✅ |
-| 007 | release-governance-v1.0.x | `scripts/`, CI, `docs/release/` | CI pipeline | ✅ |
-| 008 | e2e-runtime-reliability | `tests/e2e/`, `scripts/run-playwright.sh` | `tests/e2e/*.smoke.spec.ts` | ✅ |
-| 009 | env-contract-and-validation | `src/lib/env.ts`, `scripts/ensure-local-env.mjs` | `scripts/guard-clean-codebase.sh` | ✅ |
-| 010 | offline-session-recovery-guarantees | `src/infrastructure/local/IndexedDBSessionRepository.ts` | `tests/unit/application/indexedDbSessionRepository.test.ts` | ✅ |
-| 011 | home-install-shortcut | `src/application/appInstall/installPromptModel.ts` | `tests/unit/appInstall/installPromptModel.test.ts` | ✅ |
-| 012 | vercel-observability-clean-architecture | `src/domain/observability/`, `src/application/observability/` | `tests/unit/observability/analyticsDomain.test.ts` | ✅ |
-| 013 | stats-french-clean-architecture | `src/application/stats/`, `src/presentation/stats/` | `tests/unit/presentation/stats/` | ✅ |
-| 014 | x01-keypad-digit-scale | `components/game/Keypad.tsx` | `tests/e2e/gameplay-entry.smoke.spec.ts` | 🟡 |
-| 015 | x01-simple-two-player-limit | `src/features/game-setup/setupModel.ts` | `tests/unit/gameSetup/setupModel.test.ts` | ✅ |
-| 016 | x01-simple-bot-opponent | `src/application/scoring/x01BotTurn.ts` | `tests/unit/x01/x01BotTurn.test.ts` | ✅ |
-| 017 | killer-game | `src/domain/games/killerLogic.ts` | `tests/unit/killerLogic.test.ts` | ✅ |
-| 018 | ios12-compatibility | `vite.config.ts` legacy target, `sw.js` | CI build | 🟡 |
-| 019 | gotcha-game | `src/domain/games/gotchaLogic.ts` | `tests/unit/gotchaLogic.test.ts` | ✅ |
-| 020 | inp-phase1-quick-wins | `components/game/Keypad.tsx`, `src/app/appShell.ts` | `tests/unit/app/persistAppSession.test.ts` | ✅ |
-| 021 | score-layout-font-scale-resilience | `views/MatchView.tsx` layout CSS | `tests/e2e/gameplay-entry.smoke.spec.ts` | 🟡 |
-| 022 | arch-single-responsibility-split | `src/app/useGameLifecycle.ts`, `src/features/x01/hooks/useMatch*.ts`, `src/features/game-setup/setupPresentation.ts`, `src/lib/analyticsInstance.ts` | `tests/unit/gameSetup/setupModel.test.ts`, `tests/unit/app/appShell.test.ts` | ✅ |
+- `spec:counter/voice-scoring-reliability`
+	- Code: `src/features/x01/voice/`, `lib/deepgramToken.ts`, `api/deepgram/token.ts`, `vite.config.ts`
+	- Tests: `tests/unit/dartsSpeechParser.test.ts`, `tests/unit/x01/voicePcm.test.ts`, `tests/unit/lib/deepgramToken.test.ts`, `tests/unit/api/deepgramTokenRoute.test.ts`
+	- Issues: `#74`
+	- Status: `couvert (voice optionnel, fallback manuel obligatoire)`
 
----
+- `spec:counter/release-v1.0.2-stabilization`
+	- Code: `README.md`, `docs/architecture.md`, `docs/product-scope.md`, `docs/release/v1.0.2.md`, `docs/release/v1.0.2-coverage-map.md`, `package.json`, `package-lock.json`, `.npmrc`, `vercel.json`, `scripts/deployment-check.mjs`
+	- Tests: `npm run lint`, `npm run typecheck`, `npm run test:unit`, `npm run build`, `npm run ci:check`
+	- Issues: `#77`, `#91`, `#94`, `#95`, `#96`, `#97`, `#98`, `#99`
+	- Status: `couvert`
 
-## Synthèse
+- `spec:counter/release-governance-v1.0.x`
+	- Code: `docs/release/`, `.github/workflows/`, `scripts/guard-clean-codebase.sh`
+	- Tests: `tests/e2e/*.smoke.spec.ts`, CI quality gate
+	- Issues: `#77`
+	- Status: `couvert`
 
-- **22 specs actives**
-- **18 ✅ complètement couvertes**
-- **4 🟡 partiellement couvertes** (005, 014, 018, 021 — couverture E2E, pas de tests unitaires dédiés)
-- **0 ❌ non couvertes**
+## Zones partiellement couvertes
 
----
+- `spec:counter/ui-scoreboard-layout-consistency`
+	- Code: `views/MatchView.tsx`, `components/game/Keypad.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#95`
+	- Status: `partiel (couverture E2E smoke, pas de test unitaire dedie)`
+
+- `spec:counter/x01-keypad-digit-scale`
+	- Code: `components/game/Keypad.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#94`
+	- Status: `partiel (protege en E2E)`
+
+- `spec:counter/ios12-compatibility`
+	- Code: `vite.config.ts`, `sw.js`
+	- Tests: `tests/unit/infrastructure/legacySupport.test.ts`, CI build
+	- Issues: `#98`
+	- Status: `partiel (pas de campagne device reelle automatisee)`
+
+- `spec:counter/score-layout-font-scale-resilience`
+	- Code: `views/MatchView.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#95`
+	- Status: `partiel (protege en smoke E2E)`
+
+## Zones volontairement hors perimetre
+
+- backend metier
+- authentification metier avancee
+- profils distants persistés
+- statistiques cloud consolidees
+- logique tournoi
+- persistance backend metier
+- couplage proprietaire obligatoire avec `Bougnat_Darts_Tournaments`
+
+Status: `hors scope assume`, destine a `Bougnat_Darts_Tournaments` ou a des integrations contractuelles futures.
+
+## Synthese
+
+- `22 specs actives`
+- `18 specs completement couvertes`
+- `4 specs partiellement couvertes` : `005`, `014`, `018`, `021`
+- `0 spec non couverte`
+- `voice scoring` : supporte mais optionnel
+- `sessions locales` : supportees sans backend metier
 
 ## Tests → Specs
 
@@ -57,12 +90,12 @@
 | `tests/unit/x01/matchScoring.test.ts` | 001 |
 | `tests/unit/x01/matchPlayerScore.test.ts` | 001 |
 | `tests/unit/x01/x01BotTurn.test.ts` | 016 |
-| `tests/unit/application/matchLifecycle.test.ts` | 001 |
+| `tests/unit/application/matchLifecycle.test.ts` | 001, 002 |
 | `tests/unit/application/scoringUseCases.test.ts` | 001 |
 | `tests/unit/application/matchStats.test.ts` | 001, 013 |
 | `tests/unit/application/indexedDbSessionRepository.test.ts` | 010 |
 | `tests/unit/app/appShell.test.ts` | 001, 022 |
-| `tests/unit/app/persistAppSession.test.ts` | 020 |
+| `tests/unit/app/persistAppSession.test.ts` | 010, 020 |
 | `tests/unit/appInstall/installPromptModel.test.ts` | 011 |
 | `tests/unit/observability/analyticsDomain.test.ts` | 012 |
 | `tests/unit/observability/analyticsApplication.test.ts` | 012 |
@@ -83,3 +116,19 @@
 | `tests/e2e/gameplay-entry.smoke.spec.ts` | 001, 005, 014, 021 |
 | `tests/e2e/navigation.smoke.spec.ts` | 001, 008 |
 | `tests/e2e/completion.smoke.spec.ts` | 001, 008 |
+
+## Issues → Specs → Status
+
+| Issue ou bucket | Specs rattachees | Statut |
+|---|---|---|
+| `#70` Access Modes | 001 | Historique existant, toujours pertinent |
+| `#71` Offline Queue | 002, 010 | Historique existant, reel scope local |
+| `#74` Voice reliability | 003, 006 | Historique existant, toujours pertinent |
+| `#77` Release stabilization | 007, release `v1.0.2` | Historique existant a prolonger pour la release |
+| `#91` Open Source Release v1.0.2 | release `v1.0.2` | Issue de pilotage release active |
+| `#94` Core Scoring Engine | 001, 014, 015, 016 | Issue creee et rattachee a `M1` |
+| `#95` Game Modes Stability | 005, 017, 019, 021 | Issue creee et rattachee a `M2` |
+| `#96` Voice Scoring Reliability | 003, 006 | Issue creee et rattachee a `M3` |
+| `#97` Local Session Persistence | 002, 010, 020 | Issue creee et rattachee a `M4` |
+| `#98` Offline-first UX | 001, 008, 011, 018 | Issue creee et rattachee a `M5` |
+| `#99` Architecture & Technical Cleanup | 012, 013, 022 | Issue creee et rattachee a `M6` |

--- a/docs/release/v1.0.2.md
+++ b/docs/release/v1.0.2.md
@@ -6,6 +6,7 @@
 - open source
 - centree sur le scorage et l offline-first
 - date de consolidation: `2026-04-27`
+- issue de pilotage release: `#91`
 
 ## Resume fonctionnel
 
@@ -22,6 +23,8 @@
 ### Corrections
 - Fix scroll parasite lors de la selection de partie sur smartphone
 - Compatibilite legacy iOS 12 retablie pour les anciens iPad (iPad Air)
+- Installation Vercel alignee sur npm via `packageManager` explicite et `installCommand` stable
+- Lockfile normalise sur `registry.npmjs.org` pour eliminer la dependance a un registre prive historique
 
 ## Resume technique
 
@@ -47,6 +50,8 @@
 - `package.json` version alignée sur v1.0.2
 - ESLint `react-hooks/refs` desactive globalement — faux positif React 18 / Node 24 (rule introduite pour React 19 Compiler)
 - Keypad.tsx : `clearLongPress` et `startLongPress` encadres par `useCallback` — stabilite des callbacks
+- `vercel.json` : abandon du chemin `npm ci` fragile au profit d une installation npm explicite avec devDependencies
+- `.npmrc` : registre public npm force pour la reproductibilite CI et Dependabot
 
 ### Corrections visuelles et nommage (iteration finale)
 - **Renommage Triathlon** : "Le Triathlon" renomme en "Triathlon" — coherence avec Cricket, Capital, Gotcha, Killer, X01
@@ -61,6 +66,8 @@
 - 120+ tests unitaires : OK
 - Smoke e2e : 6 tests de navigation (un par jeu) + 4 gameplay entry — OK
 - `npm run test:e2e` avec preview local : OK (en sequence)
+- `npm run build` avec configuration npm explicite : OK
+- `package-lock.json` : plus aucune resolution vers l ancien Artifactory prive
 
 ## Hors perimetre confirme
 
@@ -71,7 +78,14 @@
 - logique tournoi avancee
 - persistance metier distante
 
+## Traçabilite GitHub
+
+- issue release: `#91`
+- milestones concernees: `M1` a `M6`, `M8`
+- issues de pilotage actives: `#94`, `#95`, `#96`, `#97`, `#98`, `#99`
+
 ## Limitations connues
 
 - le voice scoring depend d un service externe optionnel avec fallback manuel
 - les smoke E2E reposent sur un navigateur Chromium disponible sur la machine ou le runner
+- la branche `release/1.0.2` et le tag `v1.0.2` existent deja dans l historique; toute consolidation complementaire doit respecter cet historique sans retag forcé

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bougnat-darts",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bougnat-darts",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@deepgram/sdk": "^5.0.0",
         "@vercel/analytics": "^2.0.1",
@@ -32,7 +32,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.8.2",
         "typescript-eslint": "^8.57.1",
@@ -6227,9 +6227,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true,
       "license": "MIT",
@@ -56,7 +56,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
       "dev": true,
       "license": "MIT",
@@ -73,7 +73,7 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "11.2.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lru-cache/-/lru-cache-11.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -83,7 +83,7 @@
     },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "7.0.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
       "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
       "dev": true,
       "license": "MIT",
@@ -100,7 +100,7 @@
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
       "version": "11.2.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lru-cache/-/lru-cache-11.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -110,7 +110,7 @@
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
@@ -190,7 +190,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
@@ -220,7 +220,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
       "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
       "dev": true,
       "license": "MIT",
@@ -242,7 +242,7 @@
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
       "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
       "dev": true,
       "license": "MIT",
@@ -260,7 +260,7 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.6.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
       "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dev": true,
       "license": "MIT",
@@ -287,7 +287,7 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.28.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
       "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "dev": true,
       "license": "MIT",
@@ -333,7 +333,7 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
       "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "dev": true,
       "license": "MIT",
@@ -356,7 +356,7 @@
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
       "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
       "dev": true,
       "license": "MIT",
@@ -374,7 +374,7 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
       "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
@@ -392,7 +392,7 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
       "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "dev": true,
       "license": "MIT",
@@ -436,7 +436,7 @@
     },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
       "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
       "dev": true,
       "license": "MIT",
@@ -481,7 +481,7 @@
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.28.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
       "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
       "dev": true,
       "license": "MIT",
@@ -498,7 +498,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
       "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
       "dev": true,
       "license": "MIT",
@@ -514,7 +514,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
       "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
       "dev": true,
       "license": "MIT",
@@ -530,7 +530,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
       "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
       "dev": true,
       "license": "MIT",
@@ -548,7 +548,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
       "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
       "dev": true,
       "license": "MIT",
@@ -565,7 +565,7 @@
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "dev": true,
       "license": "MIT",
@@ -578,7 +578,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
       "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
       "dev": true,
       "license": "MIT",
@@ -594,7 +594,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
@@ -610,7 +610,7 @@
     },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "dev": true,
       "license": "MIT",
@@ -627,7 +627,7 @@
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
       "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
       "dev": true,
       "license": "MIT",
@@ -643,7 +643,7 @@
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
       "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
       "dev": true,
       "license": "MIT",
@@ -661,7 +661,7 @@
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
       "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
       "dev": true,
       "license": "MIT",
@@ -679,7 +679,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
       "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
       "dev": true,
       "license": "MIT",
@@ -695,7 +695,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
       "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
       "dev": true,
       "license": "MIT",
@@ -711,7 +711,7 @@
     },
     "node_modules/@babel/plugin-transform-class-properties": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
       "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
       "dev": true,
       "license": "MIT",
@@ -728,7 +728,7 @@
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
       "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
       "dev": true,
       "license": "MIT",
@@ -745,7 +745,7 @@
     },
     "node_modules/@babel/plugin-transform-classes": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
       "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
       "dev": true,
       "license": "MIT",
@@ -766,7 +766,7 @@
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
       "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
       "dev": true,
       "license": "MIT",
@@ -783,7 +783,7 @@
     },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.28.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
       "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
       "dev": true,
       "license": "MIT",
@@ -800,7 +800,7 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
       "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
       "dev": true,
       "license": "MIT",
@@ -817,7 +817,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
       "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
       "dev": true,
       "license": "MIT",
@@ -833,7 +833,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
       "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
       "dev": true,
       "license": "MIT",
@@ -850,7 +850,7 @@
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
       "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
       "dev": true,
       "license": "MIT",
@@ -866,7 +866,7 @@
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
       "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
       "dev": true,
       "license": "MIT",
@@ -883,7 +883,7 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
       "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
       "dev": true,
       "license": "MIT",
@@ -899,7 +899,7 @@
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
       "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
       "dev": true,
       "license": "MIT",
@@ -915,7 +915,7 @@
     },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
       "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
       "dev": true,
       "license": "MIT",
@@ -932,7 +932,7 @@
     },
     "node_modules/@babel/plugin-transform-function-name": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
       "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
       "dev": true,
       "license": "MIT",
@@ -950,7 +950,7 @@
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
       "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
       "dev": true,
       "license": "MIT",
@@ -966,7 +966,7 @@
     },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
       "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
       "dev": true,
       "license": "MIT",
@@ -982,7 +982,7 @@
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
       "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
       "dev": true,
       "license": "MIT",
@@ -998,7 +998,7 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
       "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
       "dev": true,
       "license": "MIT",
@@ -1014,7 +1014,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
       "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
       "dev": true,
       "license": "MIT",
@@ -1031,7 +1031,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
       "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "dev": true,
       "license": "MIT",
@@ -1048,7 +1048,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
       "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
       "dev": true,
       "license": "MIT",
@@ -1067,7 +1067,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
       "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
       "dev": true,
       "license": "MIT",
@@ -1084,7 +1084,7 @@
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
       "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
       "dev": true,
       "license": "MIT",
@@ -1101,7 +1101,7 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
       "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
       "dev": true,
       "license": "MIT",
@@ -1117,7 +1117,7 @@
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
       "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
       "dev": true,
       "license": "MIT",
@@ -1133,7 +1133,7 @@
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
       "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
       "dev": true,
       "license": "MIT",
@@ -1149,7 +1149,7 @@
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
       "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
       "dev": true,
       "license": "MIT",
@@ -1169,7 +1169,7 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
       "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
       "dev": true,
       "license": "MIT",
@@ -1186,7 +1186,7 @@
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
       "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
       "dev": true,
       "license": "MIT",
@@ -1202,7 +1202,7 @@
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
       "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
       "dev": true,
       "license": "MIT",
@@ -1219,7 +1219,7 @@
     },
     "node_modules/@babel/plugin-transform-parameters": {
       "version": "7.27.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
       "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "dev": true,
       "license": "MIT",
@@ -1235,7 +1235,7 @@
     },
     "node_modules/@babel/plugin-transform-private-methods": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
       "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
       "dev": true,
       "license": "MIT",
@@ -1252,7 +1252,7 @@
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
       "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
       "dev": true,
       "license": "MIT",
@@ -1270,7 +1270,7 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
       "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
       "dev": true,
       "license": "MIT",
@@ -1318,7 +1318,7 @@
     },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
       "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
       "dev": true,
       "license": "MIT",
@@ -1334,7 +1334,7 @@
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
       "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
       "dev": true,
       "license": "MIT",
@@ -1351,7 +1351,7 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
       "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
       "dev": true,
       "license": "MIT",
@@ -1367,7 +1367,7 @@
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
       "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
       "dev": true,
       "license": "MIT",
@@ -1383,7 +1383,7 @@
     },
     "node_modules/@babel/plugin-transform-spread": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
       "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
       "dev": true,
       "license": "MIT",
@@ -1400,7 +1400,7 @@
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
       "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
       "dev": true,
       "license": "MIT",
@@ -1416,7 +1416,7 @@
     },
     "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "dev": true,
       "license": "MIT",
@@ -1432,7 +1432,7 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
       "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
       "dev": true,
       "license": "MIT",
@@ -1448,7 +1448,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
       "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
       "dev": true,
       "license": "MIT",
@@ -1464,7 +1464,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
       "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
       "dev": true,
       "license": "MIT",
@@ -1481,7 +1481,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
       "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
       "dev": true,
       "license": "MIT",
@@ -1498,7 +1498,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.28.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
       "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
       "dev": true,
       "license": "MIT",
@@ -1515,7 +1515,7 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.29.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
       "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
@@ -1600,7 +1600,7 @@
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "dev": true,
       "license": "MIT",
@@ -1663,7 +1663,7 @@
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
@@ -1676,7 +1676,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
@@ -1696,7 +1696,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
       "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
       "dev": true,
       "funding": [
@@ -1720,7 +1720,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
       "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
       "dev": true,
       "funding": [
@@ -1748,7 +1748,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
@@ -1771,7 +1771,7 @@
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
       "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
       "dev": true,
       "funding": [
@@ -1796,7 +1796,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
@@ -1816,7 +1816,7 @@
     },
     "node_modules/@deepgram/sdk": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@deepgram/sdk/-/sdk-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@deepgram/sdk/-/sdk-5.0.0.tgz",
       "integrity": "sha512-x1wMiOgDGqcLEaQpQBQLTtk5mLbXbYgcBEpp7cfJIyEtqdIGgijCZH+a/esiVp+xIcTYYroTxG47RVppZOHbWw==",
       "license": "MIT",
       "dependencies": {
@@ -2321,7 +2321,7 @@
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
@@ -2402,7 +2402,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
@@ -2486,7 +2486,7 @@
     },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
@@ -2504,7 +2504,7 @@
     },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/address/-/address-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
       "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2517,28 +2517,28 @@
     },
     "node_modules/@hapi/formula": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/formula/-/formula-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
       "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/hoek": {
       "version": "11.0.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
       "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
       "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/tlds": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
       "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2548,7 +2548,7 @@
     },
     "node_modules/@hapi/topo": {
       "version": "6.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@hapi/topo/-/topo-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
       "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2642,7 +2642,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
@@ -2672,7 +2672,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@playwright/test/-/test-1.58.2.tgz",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3045,14 +3045,14 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/node/-/node-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
       "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
       "dev": true,
       "license": "MIT",
@@ -3068,7 +3068,7 @@
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
       "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
       "dev": true,
       "license": "MIT",
@@ -3092,7 +3092,7 @@
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
       "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
       "cpu": [
         "arm64"
@@ -3109,7 +3109,7 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
       "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
       "cpu": [
         "arm64"
@@ -3126,7 +3126,7 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
       "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
       "cpu": [
         "x64"
@@ -3143,7 +3143,7 @@
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
       "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
       "cpu": [
         "x64"
@@ -3160,7 +3160,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
       "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
       "cpu": [
         "arm"
@@ -3177,7 +3177,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
       "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
       "cpu": [
         "arm64"
@@ -3194,7 +3194,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
@@ -3211,7 +3211,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
       "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
       "cpu": [
         "x64"
@@ -3228,7 +3228,7 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
@@ -3245,7 +3245,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
       "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
@@ -3339,7 +3339,7 @@
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
       "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
       "cpu": [
         "arm64"
@@ -3356,7 +3356,7 @@
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
       "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
       "cpu": [
         "x64"
@@ -3373,7 +3373,7 @@
     },
     "node_modules/@tailwindcss/postcss": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
       "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
       "dev": true,
       "license": "MIT",
@@ -3387,7 +3387,7 @@
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
       "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
       "dev": true,
       "license": "MIT",
@@ -3447,7 +3447,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@types/chai/-/chai-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
@@ -3458,7 +3458,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
@@ -3489,14 +3489,14 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@types/react/-/react-18.3.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
@@ -3507,7 +3507,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
@@ -3843,7 +3843,7 @@
     },
     "node_modules/@vitejs/plugin-legacy": {
       "version": "6.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitejs/plugin-legacy/-/plugin-legacy-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-6.1.1.tgz",
       "integrity": "sha512-BvusL+mYZ0q5qS5Rq3D70QxZBmhyiHRaXLtYJHH5AEsAmdSqJR4xe5KwMi1H3w8/9lVJwhkLYqFQ9vmWYWy6kA==",
       "dev": true,
       "license": "MIT",
@@ -3891,7 +3891,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/expect/-/expect-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
       "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
       "dev": true,
       "license": "MIT",
@@ -3909,7 +3909,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
       "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
       "dev": true,
       "license": "MIT",
@@ -3936,7 +3936,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
       "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
       "dev": true,
       "license": "MIT",
@@ -3949,7 +3949,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/runner/-/runner-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
       "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
       "dev": true,
       "license": "MIT",
@@ -3963,7 +3963,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
       "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
       "dev": true,
       "license": "MIT",
@@ -3979,7 +3979,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/spy/-/spy-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
       "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
       "dev": true,
       "license": "MIT",
@@ -3989,7 +3989,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/@vitest/utils/-/utils-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
       "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
       "dev": true,
       "license": "MIT",
@@ -4067,7 +4067,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
@@ -4077,14 +4077,14 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
       "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
       "dev": true,
       "funding": [
@@ -4121,7 +4121,7 @@
     },
     "node_modules/axios": {
       "version": "1.15.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/axios/-/axios-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
       "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
@@ -4133,7 +4133,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
       "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dev": true,
       "license": "MIT",
@@ -4148,7 +4148,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.14.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
       "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "dev": true,
       "license": "MIT",
@@ -4162,7 +4162,7 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
       "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dev": true,
       "license": "MIT",
@@ -4198,7 +4198,7 @@
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/bidi-js/-/bidi-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
@@ -4208,7 +4208,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -4255,7 +4255,7 @@
     },
     "node_modules/browserslist-to-esbuild": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
       "integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
       "dev": true,
       "license": "MIT",
@@ -4274,7 +4274,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT",
@@ -4282,7 +4282,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -4327,7 +4327,7 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/chai/-/chai-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
@@ -4374,7 +4374,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "license": "MIT",
@@ -4387,7 +4387,7 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/commander/-/commander-2.20.3.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT",
@@ -4409,7 +4409,7 @@
     },
     "node_modules/core-js": {
       "version": "3.49.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/core-js/-/core-js-3.49.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "dev": true,
       "hasInstallScript": true,
@@ -4421,7 +4421,7 @@
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
       "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
@@ -4450,7 +4450,7 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/css-tree/-/css-tree-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
@@ -4464,14 +4464,14 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/data-urls/-/data-urls-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
@@ -4503,7 +4503,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/decimal.js/-/decimal.js-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
@@ -4517,7 +4517,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "license": "MIT",
@@ -4527,7 +4527,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4537,7 +4537,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -4559,7 +4559,7 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
@@ -4573,7 +4573,7 @@
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4586,7 +4586,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -4596,7 +4596,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -4606,14 +4606,14 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
@@ -4626,7 +4626,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
@@ -4834,7 +4834,7 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
@@ -4948,7 +4948,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
@@ -4968,7 +4968,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/expect-type/-/expect-type-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5068,7 +5068,7 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
@@ -5089,7 +5089,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.5",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/form-data/-/form-data-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
@@ -5106,7 +5106,7 @@
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/fraction.js/-/fraction.js-5.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
       "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
       "license": "MIT",
@@ -5135,7 +5135,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
@@ -5155,7 +5155,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
@@ -5180,7 +5180,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -5220,7 +5220,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -5233,7 +5233,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
@@ -5250,7 +5250,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -5263,7 +5263,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -5279,7 +5279,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
@@ -5309,7 +5309,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
@@ -5359,7 +5359,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/is-core-module/-/is-core-module-2.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
@@ -5398,7 +5398,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
@@ -5412,7 +5412,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/jiti/-/jiti-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
@@ -5422,7 +5422,7 @@
     },
     "node_modules/joi": {
       "version": "18.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/joi/-/joi-18.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.1.tgz",
       "integrity": "sha512-pJkBiPtNo+o0h19LfSvUN46Y5zY+ck99AtHwch9n2HqVLNRgP0ZMyIH8FRMoP+HV8hy/+AG99dXFfwpf83iZfQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -5460,7 +5460,7 @@
     },
     "node_modules/jsdom": {
       "version": "29.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/jsdom/-/jsdom-29.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
@@ -5501,7 +5501,7 @@
     },
     "node_modules/jsdom/node_modules/lru-cache": {
       "version": "11.2.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lru-cache/-/lru-cache-11.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5582,7 +5582,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -5612,7 +5612,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -5633,7 +5633,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -5654,7 +5654,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -5675,7 +5675,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -5696,7 +5696,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -5717,7 +5717,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -5738,7 +5738,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -5759,7 +5759,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -5780,7 +5780,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -5801,7 +5801,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -5822,7 +5822,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -5859,14 +5859,14 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
@@ -5911,7 +5911,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/magic-string/-/magic-string-0.30.21.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
@@ -5921,7 +5921,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -5931,14 +5931,14 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/mdn-data/-/mdn-data-2.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/meow": {
       "version": "13.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/meow/-/meow-13.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
       "license": "MIT",
@@ -5951,7 +5951,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
@@ -5961,7 +5961,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
@@ -5990,7 +5990,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
@@ -6040,7 +6040,7 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/obug/-/obug-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
@@ -6114,7 +6114,7 @@
     },
     "node_modules/parse5": {
       "version": "8.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/parse5/-/parse5-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
       "license": "MIT",
@@ -6147,14 +6147,14 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/pathe/-/pathe-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
@@ -6168,7 +6168,7 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -6181,7 +6181,7 @@
     },
     "node_modules/playwright": {
       "version": "1.58.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/playwright/-/playwright-1.58.2.tgz",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
@@ -6200,7 +6200,7 @@
     },
     "node_modules/playwright-core": {
       "version": "1.58.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/playwright-core/-/playwright-core-1.58.2.tgz",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -6213,7 +6213,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/fsevents/-/fsevents-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
@@ -6257,7 +6257,7 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
@@ -6274,7 +6274,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
       "license": "MIT",
@@ -6329,14 +6329,14 @@
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regenerate/-/regenerate-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
       "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
       "dev": true,
       "license": "MIT",
@@ -6349,14 +6349,14 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
       "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
       "dev": true,
       "license": "MIT",
@@ -6374,14 +6374,14 @@
     },
     "node_modules/regjsgen": {
       "version": "0.8.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regjsgen/-/regjsgen-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/regjsparser": {
       "version": "0.13.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/regjsparser/-/regjsparser-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
       "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6394,7 +6394,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -6404,7 +6404,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
@@ -6481,7 +6481,7 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/rxjs/-/rxjs-7.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -6491,7 +6491,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/saxes/-/saxes-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
@@ -6546,14 +6546,14 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/siginfo/-/siginfo-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6574,7 +6574,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/source-map-support/-/source-map-support-0.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
@@ -6586,14 +6586,14 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/stackback/-/stackback-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/std-env/-/std-env-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
@@ -6626,7 +6626,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
@@ -6639,28 +6639,28 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/systemjs": {
       "version": "6.15.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/systemjs/-/systemjs-6.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.15.1.tgz",
       "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tapable/-/tapable-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
@@ -6674,7 +6674,7 @@
     },
     "node_modules/terser": {
       "version": "5.46.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/terser/-/terser-5.46.2.tgz",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
       "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6694,14 +6694,14 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tinybench/-/tinybench-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tinyexec/-/tinyexec-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
       "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
@@ -6728,7 +6728,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
@@ -6738,7 +6738,7 @@
     },
     "node_modules/tldts": {
       "version": "7.0.27",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tldts/-/tldts-7.0.27.tgz",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
       "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
       "dev": true,
       "license": "MIT",
@@ -6751,14 +6751,14 @@
     },
     "node_modules/tldts-core": {
       "version": "7.0.27",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tldts-core/-/tldts-core-7.0.27.tgz",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6771,7 +6771,7 @@
     },
     "node_modules/tr46": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/tr46/-/tr46-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
@@ -6855,7 +6855,7 @@
     },
     "node_modules/undici": {
       "version": "7.24.6",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/undici/-/undici-7.24.6.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
       "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
@@ -6872,7 +6872,7 @@
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
       "license": "MIT",
@@ -6882,7 +6882,7 @@
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
       "license": "MIT",
@@ -6896,7 +6896,7 @@
     },
     "node_modules/unicode-match-property-value-ecmascript": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
       "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
       "dev": true,
       "license": "MIT",
@@ -6906,7 +6906,7 @@
     },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
       "dev": true,
       "license": "MIT",
@@ -6957,7 +6957,7 @@
     },
     "node_modules/vite": {
       "version": "6.4.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/vite/-/vite-6.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
@@ -7032,7 +7032,7 @@
     },
     "node_modules/vitest": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/vitest/-/vitest-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
@@ -7114,7 +7114,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
@@ -7127,7 +7127,7 @@
     },
     "node_modules/wait-on": {
       "version": "9.0.4",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/wait-on/-/wait-on-9.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.4.tgz",
       "integrity": "sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==",
       "dev": true,
       "license": "MIT",
@@ -7147,7 +7147,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -7157,7 +7157,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
@@ -7167,7 +7167,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "16.0.1",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
@@ -7198,7 +7198,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
@@ -7246,7 +7246,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -7256,7 +7256,7 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.michelin.com/api/npm/npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bougnat-darts",
   "private": true,
   "version": "1.0.2",
+  "packageManager": "npm@10.9.7",
   "type": "module",
   "scripts": {
     "dev": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.57.1",
@@ -56,6 +56,7 @@
     "axios": "1.15.2",
     "follow-redirects": "1.16.0",
     "lodash": "4.18.1",
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "postcss": "$postcss"
   }
 }

--- a/scripts/run-playwright.sh
+++ b/scripts/run-playwright.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIB_ROOT="$ROOT_DIR/.cache/playwright-libs/root/usr/lib/x86_64-linux-gnu"
 DEB_DIR="$ROOT_DIR/.cache/playwright-libs/debs"
+PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL:-http://127.0.0.1:4173}"
+PREVIEW_PID=""
 
 ensure_local_linux_deps() {
   if [[ "$(uname -s)" != "Linux" ]]; then
@@ -63,4 +65,31 @@ if [[ -d "$LIB_ROOT" ]]; then
   export LD_LIBRARY_PATH="$LIB_ROOT:${LD_LIBRARY_PATH:-}"
 fi
 
-exec npm exec -- playwright "$@"
+cleanup_preview() {
+  if [[ -n "$PREVIEW_PID" ]] && kill -0 "$PREVIEW_PID" 2>/dev/null; then
+    kill "$PREVIEW_PID" 2>/dev/null || true
+    wait "$PREVIEW_PID" 2>/dev/null || true
+  fi
+}
+
+start_local_preview() {
+  if [[ -n "${PLAYWRIGHT_EXTERNAL_SERVER:-}" ]]; then
+    return 0
+  fi
+
+  (
+    cd "$ROOT_DIR"
+    npm run preview -- --host 127.0.0.1 --port 4173 >/tmp/bougnat-playwright-preview.log 2>&1
+  ) &
+  PREVIEW_PID=$!
+  trap cleanup_preview EXIT
+
+  (
+    cd "$ROOT_DIR"
+    npm exec -- wait-on "$PLAYWRIGHT_BASE_URL"
+  )
+}
+
+start_local_preview
+cd "$ROOT_DIR"
+PLAYWRIGHT_BASE_URL="$PLAYWRIGHT_BASE_URL" exec npm exec -- playwright "$@"

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "npm run build",
-  "installCommand": "npm ci",
+  "installCommand": "npm install --include=dev --no-audit --no-fund",
   "outputDirectory": "dist",
   "headers": [
     {


### PR DESCRIPTION
## Résumé fonctionnel

Cette release stabilise `Bougnat_darts_counter` comme base open source centrée exclusivement sur le scoring, les jeux supportés, le voice scoring `X01` optionnel, les sessions locales et l expérience offline-first.

Contenu confirmé :
- X01, Cricket, Capital, Triathlon, Killer, Gotcha
- scorage manuel toujours disponible
- voice scoring `X01` optionnel avec fallback manuel
- persistance locale et reprise de session
- exécution sans backend métier obligatoire

Hors périmètre confirmé :
- authentification métier avancée
- profils distants persistés
- statistiques cloud consolidées
- logique tournoi
- persistance backend métier
- couplage propriétaire obligatoire avec `Bougnat_Darts_Tournaments`

## Résumé technique

- alignement du contrat d installation sur npm avec `packageManager: npm@10.9.7`
- normalisation du lockfile sur `registry.npmjs.org` et ajout de `.npmrc`
- correction Vercel/CI pour éviter le chemin fragile `npm ci`
- clarification documentaire du périmètre open source dans `README`, `docs/product-scope.md`, `docs/architecture.md`
- remise au format canonique de la coverage map `spec -> code -> tests -> issues -> status`
- correction du lanceur Playwright pour démarrer automatiquement `vite preview` avant les smoke E2E

## Résumé spec-driven

Specs dominantes consolidées dans cette release :
- `spec:counter/release-governance-v1.0.x`
- `spec:counter/env-contract-and-validation`
- `spec:counter/e2e-runtime-reliability`
- `spec:counter/arch-single-responsibility-split`
- `spec:counter/scoring-access-modes`
- `spec:counter/offline-scoring-terminal-foundation`
- `spec:counter/offline-session-recovery-guarantees`
- `spec:counter/voice-scoring-reliability`
- `spec:counter/voice-token-provisioning-hardening`

## Issues fermées

Closes #91

Issues de pilotage liées :
- #94 Core Scoring Engine
- #95 Game Modes Stability
- #96 Voice Scoring Reliability
- #97 Local Session Persistence
- #98 Offline-first UX
- #99 Architecture & Technical Cleanup

## Milestones concernées

- M1: Core Scoring Engine
- M2: Game Modes Stability
- M3: Voice Scoring Reliability
- M4: Local Session Persistence
- M5: Offline-first UX
- M6: Architecture & Technical Cleanup
- M8: Open Source Release v1.0.2

## Coverage map synthétique

- 22 specs actives
- 18 specs complètement couvertes
- 4 specs partiellement couvertes : 005, 014, 018, 021
- 0 spec non couverte
- mapping GitHub actif : #91, #94, #95, #96, #97, #98, #99

## Vérifications effectuées

- `npm run ci:check` sur `develop` : OK
- `npm run ci:check` sur `release/1.0.2` : OK
- `npm run test:e2e` sur `release/1.0.2` : OK, 13 smoke tests passés
- contrôle lockfile : plus aucune résolution vers l ancien Artifactory privé
- contrôle périmètre : aucun backend métier runtime requis pour jouer

## Release notes complètes

### Stabilisation release / CI
- installation Vercel alignée sur npm via `packageManager` explicite et `installCommand` stable
- lockfile normalisé sur le registre public npm pour supprimer le reliquat de registre privé
- audit de sécurité/déploiement aligné sur la configuration effective

### Clarification open source
- README mis à jour avec contenu, hors périmètre et séparation explicite avec `Bougnat_Darts_Tournaments`
- `CONTRIBUTING.md` recentré sur le socle scoring offline-first
- `docs/product-scope.md` et `docs/architecture.md` consolidés sur la frontière open source / métier propriétaire
- `docs/release/v1.0.2.md` et `docs/release/v1.0.2-coverage-map.md` remis à jour avec la traçabilité GitHub

### Validation release locale
- `scripts/run-playwright.sh` démarre désormais automatiquement la preview locale pour exécuter les smoke E2E sans orchestration manuelle
- la validation locale couvre l accueil, le lancement de partie, l entrée dans chaque jeu, le retour et les smoke gameplay minimaux

## Known limitations

- le voice scoring dépend d un service externe optionnel et conserve un fallback manuel obligatoire
- 4 specs restent partiellement couvertes via smoke E2E plutôt que tests unitaires dédiés : 005, 014, 018, 021
- le tag `v1.0.2` existait déjà dans l historique avant cette consolidation; il n a pas été retagué par respect de l immuabilité Git
