### PR TITLE
Fix repeated bot victory popup

### DIFF
--- a/src/features/x01/scoring/botVictoryPreview.ts
+++ b/src/features/x01/scoring/botVictoryPreview.ts
@@ -1,0 +1,37 @@
+import type { MatchState } from '../../../../types';
+
+type ResolveBotVictoryPreviewParams = {
+  previousMatch: MatchState;
+  nextMatch: MatchState;
+  currentPlayerTeamId: string;
+  showWinnerScreen: boolean;
+};
+
+type BotVictoryPreviewResolution = {
+  hasBotWonLeg: boolean;
+  hasBotWonMatch: boolean;
+  previewKind: 'leg' | 'match' | null;
+};
+
+export const resolveBotVictoryPreview = ({
+  previousMatch,
+  nextMatch,
+  currentPlayerTeamId,
+  showWinnerScreen,
+}: ResolveBotVictoryPreviewParams): BotVictoryPreviewResolution => {
+  const advancedToNextLeg =
+    !showWinnerScreen
+    && nextMatch.completedLegs.length > previousMatch.completedLegs.length
+    && nextMatch.currentLeg.history.length === 0;
+  const completedLeg = advancedToNextLeg
+    ? nextMatch.completedLegs[nextMatch.completedLegs.length - 1]
+    : null;
+  const hasBotWonMatch = showWinnerScreen && nextMatch.matchWinnerId === currentPlayerTeamId;
+  const hasBotWonLeg = advancedToNextLeg && completedLeg?.winnerId === currentPlayerTeamId;
+
+  return {
+    hasBotWonLeg,
+    hasBotWonMatch,
+    previewKind: hasBotWonMatch ? 'match' : hasBotWonLeg ? 'leg' : null,
+  };
+};

--- a/tests/unit/x01/botVictoryPreview.test.ts
+++ b/tests/unit/x01/botVictoryPreview.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMatch, submitTurn } from '../../../src/application/scoring/matchLifecycle';
+import { resolveBotVictoryPreview } from '../../../src/features/x01/scoring/botVictoryPreview';
+import type { GameConfig, Player } from '../../../types';
+
+const players: Player[] = [
+  { id: 'p1', name: 'Joueur 1', teamId: 'p1' },
+  { id: 'p2', name: 'Robot', teamId: 'p2', isBot: true, botLevel: 'CLUB' },
+];
+
+const config: GameConfig = {
+  startingScore: 40,
+  checkIn: 'Open',
+  checkOut: 'Double',
+  matchMode: 'LEGS',
+  setsToWin: 1,
+  legsToWin: 2,
+  isDoubles: false,
+  initialStartingPlayerIndex: 0,
+};
+
+describe('resolveBotVictoryPreview', () => {
+  it('returns a leg preview only when the bot just advanced the match to the next leg', () => {
+    const match = createMatch(players, config);
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotLegWin = submitTurn(afterHumanMiss, 40, 1);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterHumanMiss,
+      nextMatch: afterBotLegWin,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: false,
+    })).toEqual({
+      hasBotWonLeg: true,
+      hasBotWonMatch: false,
+      previewKind: 'leg',
+    });
+  });
+
+  it('does not retrigger the leg preview on later bot turns after an earlier bot leg win', () => {
+    const match = createMatch(players, config);
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotLegWin = submitTurn(afterHumanMiss, 40, 1);
+    const afterNextBotTurn = submitTurn(afterBotLegWin, 0, 3);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterBotLegWin,
+      nextMatch: afterNextBotTurn,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: false,
+    })).toEqual({
+      hasBotWonLeg: false,
+      hasBotWonMatch: false,
+      previewKind: null,
+    });
+  });
+
+  it('returns a match preview when the bot closes the match', () => {
+    const match = createMatch(players, { ...config, legsToWin: 1 });
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotMatchWin = submitTurn(afterHumanMiss, 40, 1);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterHumanMiss,
+      nextMatch: afterBotMatchWin,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: true,
+    })).toEqual({
+      hasBotWonLeg: false,
+      hasBotWonMatch: true,
+      previewKind: 'match',
+    });
+  });
+});

--- a/views/MatchView.tsx
+++ b/views/MatchView.tsx
@@ -22,6 +22,7 @@ import { VoiceScoringControl } from '../src/features/x01/voice/VoiceScoringContr
 import { buildCheckoutConfirmResult, buildScoreSubmissionResult, cloneMatchState, type FeedbackKind } from '../src/features/x01/scoring/matchSubmission';
 import { deriveRemainingPreview, type RemainingPreview } from '../src/features/x01/scoring/matchPreview';
 import { getFeedbackStyles } from '../src/features/x01/scoring/matchFeedback';
+import { resolveBotVictoryPreview } from '../src/features/x01/scoring/botVictoryPreview';
 import { getMatchFormatCompactText, getMatchFormatText, getStarterOptions, getWinnerDisplayName } from '../src/features/x01/scoring/matchPresentation';
 import { buildPlayerScoreViewModel } from '../src/features/x01/scoring/matchPlayerScore';
 import { buildX01BotTurnResult } from '../src/application/x01Bot/x01BotTurn';
@@ -568,11 +569,12 @@ export const MatchView: React.FC<MatchViewProps> = ({
         level: currentPlayer.botLevel ?? DEFAULT_X01_BOT_LEVEL,
         elapsedSeconds,
       });
-      const completedLeg = result.nextMatch.completedLegs[result.nextMatch.completedLegs.length - 1];
-      const hasBotWonLeg =
-        result.nextMatch.matchWinnerId === currentPlayer.teamId
-        || completedLeg?.winnerId === currentPlayer.teamId
-        || result.nextMatch.currentLeg.winnerId === currentPlayer.teamId;
+      const { hasBotWonLeg, hasBotWonMatch, previewKind } = resolveBotVictoryPreview({
+        previousMatch: match,
+        nextMatch: result.nextMatch,
+        currentPlayerTeamId: currentPlayer.teamId,
+        showWinnerScreen: result.showWinnerScreen,
+      });
 
       setUndoStack((prev) => [
         ...prev,
@@ -591,13 +593,13 @@ export const MatchView: React.FC<MatchViewProps> = ({
       setRemainingPreview(null);
       resetVoiceStreaming();
       void persistSharedState(result.persistMatch);
-      if (hasBotWonLeg) {
+      if (hasBotWonMatch || hasBotWonLeg) {
         showBotVictoryPreview(
           {
-            kind: result.showWinnerScreen ? 'match' : 'leg',
+            kind: previewKind ?? 'leg',
             winnerName: currentPlayer.name,
           },
-          result.showWinnerScreen ? () => setShowWinnerScreen(true) : undefined,
+          hasBotWonMatch ? () => setShowWinnerScreen(true) : undefined,
         );
       } else {
         setShowWinnerScreen(result.showWinnerScreen);


### PR DESCRIPTION
## Summary
Fix the X01 bot victory preview so the leg-win popup only appears when the bot has actually just won a new leg or the match.

## Changes
- extract the bot victory preview decision into a dedicated helper
- stop reusing a previously completed bot leg as the trigger for later popups
- add regression coverage for repeated bot turns after a prior bot leg win

## Validation
- npm run test:unit -- tests/unit/x01/botVictoryPreview.test.ts
- workspace diagnostics on touched files show no errors