### PR TITLE
release: v1.1

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,7 +10,6 @@ VITE_APP_ENV=local
 VITE_APP_NAME=Bougnat Darts Counter
 VITE_APP_VERSION=dev
 VITE_APP_URL=http://localhost:3000
-VITE_TOURNAMENT_API_URL=
 VITE_APP_ACCESS_MODE=local
 
 # Optional local-only toggles

--- a/App.tsx
+++ b/App.tsx
@@ -19,11 +19,13 @@ import {
 import { useAppScreenHistory } from './src/app/useAppScreenHistory';
 import {
   ANALYTICS_EVENT,
+  buildAnalyticsPageView,
   buildGameFeatureFlags,
 } from './src/domain/observability/analyticsDomain';
 import {
   syncFeatureFlags,
   trackAnalyticsEvent,
+  trackPageView,
 } from './src/application/observability/analyticsUseCases';
 import { analytics } from './src/lib/analyticsInstance';
 import { useGameLifecycle } from './src/app/useGameLifecycle';
@@ -84,6 +86,11 @@ export const App: React.FC = () => {
         appAccessMode: env.VITE_APP_ACCESS_MODE,
       }),
     [currentMatch?.config.isDoubles, screen, selectedGameType],
+  );
+
+  const pageView = useMemo(
+    () => buildAnalyticsPageView(screen, selectedGameType),
+    [screen, selectedGameType],
   );
 
   useEffect(() => {
@@ -161,6 +168,8 @@ export const App: React.FC = () => {
       return;
     }
 
+    trackPageView(analytics, pageView);
+
     const previousScreen = previousScreenRef.current;
     trackAnalyticsEvent(analytics, ANALYTICS_EVENT.ScreenView, {
       screen,
@@ -169,7 +178,7 @@ export const App: React.FC = () => {
       has_active_match: Boolean(currentMatch || matchRuntime),
     });
     previousScreenRef.current = screen;
-  }, [currentMatch, isSessionHydrated, matchRuntime, screen, selectedGameType]);
+  }, [currentMatch, isSessionHydrated, matchRuntime, pageView, screen, selectedGameType]);
 
   useAppScreenHistory(screen, setScreen);
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 - documenter les changements structurants dans les specs et les docs d architecture
 - ne pas reintroduire de dependance runtime a un backend metier dans le perimetre supporte
 
-## Frontiere open source `v1.0.2`
+## Frontiere open source `v1.1`
 
 Les contributions attendues doivent renforcer ou clarifier :
 
@@ -50,7 +50,7 @@ npm run test:e2e
 
 ## Orientation produit
 
-Les contributions attendues pour `v1.0.2+` concernent en priorite :
+Les contributions attendues pour `v1.1+` concernent en priorite :
 
 - scoring
 - jeux

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Une base simple et efficace pour structurer le scoring, accueillir les joueurs e
 
 Le scorage manuel reste toujours disponible. L'assistance vocale peut accompagner le X01 quand elle est activee, mais le jeu ne depend jamais du micro.
 
-## ✅ Statut de la base `v1.0.2`
+## ✅ Statut de la base `v1.1`
 
-`Bougnat_darts_counter` est publie comme une base open source stable centree sur :
+`Bougnat_darts_counter` est aligne pour la release open source stable `v1.1`, centree sur :
 
 - le moteur de scoring
 - les jeux de flechettes supportes
@@ -63,7 +63,7 @@ Le scorage manuel reste toujours disponible. L'assistance vocale peut accompagne
 - la reprise locale
 - l experience offline-first
 
-Le runtime supporte en `v1.0.2` ne depend d aucun backend metier obligatoire.
+Le runtime supporte en `v1.1` ne depend d aucun backend metier obligatoire.
 
 ## 🚫 Hors perimetre explicite
 
@@ -84,7 +84,7 @@ Les integrations externes eventuelles doivent rester contractuelles et optionnel
 
 `Bougnat_Darts_Tournaments` est le systeme maitre metier reserve a l orchestration tournoi, aux donnees proprietaires et aux integrations backend explicites.
 
-La frontiere `v1.0.2` impose qu aucune logique proprietaire ne soit necessaire pour lancer, scorer, corriger, annuler, terminer et reprendre localement une partie.
+La frontiere `v1.1` impose qu aucune logique proprietaire ne soit necessaire pour lancer, scorer, corriger, annuler, terminer et reprendre localement une partie.
 
 ## ❤️ Pourquoi les joueurs l'aiment
 
@@ -138,8 +138,9 @@ Chaque retour terrain compte.
 - [Perimetre produit](docs/product-scope.md)
 - [Securite](SECURITY.md)
 - [Contribuer](CONTRIBUTING.md)
+- [Notes de version v1.1](docs/release/v1.1.md)
+- [Coverage map v1.1](docs/release/v1.1-coverage-map.md)
 - [Notes de version v1.0.2](docs/release/v1.0.2.md)
-- [Coverage map v1.0.2](docs/release/v1.0.2-coverage-map.md)
 
 ## 📄 Licence
 

--- a/components/game-setup/SetupPlayersSection.tsx
+++ b/components/game-setup/SetupPlayersSection.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { Bot, Swords, Users } from 'lucide-react';
+
+import type { GameType } from '../../utils/arenaFlow';
+import type { X01BotLevel } from '../../types';
+import { formatX01BotAverageRange, X01_BOT_LEVELS } from '../../src/domain/x01Bot/x01Bot';
+import { buildTeamStarterOptions, canEnableBotOpponent, getBotLevelLabel, getSetupPlayerCountOptions, supportsDoublesMode } from '../../src/features/game-setup/setupViewModel';
+import { PlayerNameField } from './PlayerNameField';
+import { setupActiveOptionClass, setupInactiveOptionClass, setupLabelClass, setupSectionClass } from './setupViewStyles';
+
+interface SetupPlayersSectionProps {
+  gameType: GameType;
+  isDoubles: boolean;
+  playerNames: string[];
+  team1Names: string[];
+  team2Names: string[];
+  teamStarterIds: Record<string, string>;
+  playAgainstBot: boolean;
+  botLevel: X01BotLevel;
+  onSetDoubles: (value: boolean) => void;
+  onSetPlayerCount: (count: number) => void;
+  onUpdatePlayerName: (index: number, name: string) => void;
+  onUpdateTeamName: (team: 1 | 2, index: number, name: string) => void;
+  onUpdateTeamStarter: (teamId: 'team1' | 'team2', playerId: string) => void;
+  onToggleBot: (value: boolean) => void;
+  onSetBotLevel: (value: X01BotLevel) => void;
+}
+
+export const SetupPlayersSection: React.FC<SetupPlayersSectionProps> = ({
+  gameType,
+  isDoubles,
+  playerNames,
+  team1Names,
+  team2Names,
+  teamStarterIds,
+  playAgainstBot,
+  botLevel,
+  onSetDoubles,
+  onSetPlayerCount,
+  onUpdatePlayerName,
+  onUpdateTeamName,
+  onUpdateTeamStarter,
+  onToggleBot,
+  onSetBotLevel,
+}) => {
+  const canPlayAgainstBot = canEnableBotOpponent(gameType, isDoubles);
+  const playerCountOptions = getSetupPlayerCountOptions(gameType);
+  const team1StarterOptions = buildTeamStarterOptions('team1', team1Names);
+  const team2StarterOptions = buildTeamStarterOptions('team2', team2Names);
+
+  return (
+    <section className={setupSectionClass}>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className={`${setupLabelClass} mb-0`}>Joueurs</label>
+        {supportsDoublesMode(gameType) && (
+          <div className="inline-flex rounded-2xl border border-white/10 bg-black/20 p-1">
+            <button
+              onClick={() => onSetDoubles(false)}
+              className={`rounded-xl px-4 py-2 text-xs font-black uppercase tracking-[0.18em] transition-all ${!isDoubles ? 'bg-white/10 text-white' : 'text-gray-500 hover:text-white'}`}
+            >
+              <Users className="mr-2 inline h-4 w-4" />
+              Simple
+            </button>
+            <button
+              onClick={() => onSetDoubles(true)}
+              className={`rounded-xl px-4 py-2 text-xs font-black uppercase tracking-[0.18em] transition-all ${isDoubles ? 'bg-white/10 text-white' : 'text-gray-500 hover:text-white'}`}
+            >
+              <Swords className="mr-2 inline h-4 w-4" />
+              Doublettes
+            </button>
+          </div>
+        )}
+      </div>
+
+      {!isDoubles ? (
+        <>
+          <div className="mb-5 rounded-2xl border border-white/10 bg-black/20 p-4">
+            <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Nombre De Joueurs</div>
+            <div className="grid grid-cols-4 gap-2">
+              {playerCountOptions.map((count) => (
+                <button
+                  key={count}
+                  type="button"
+                  onClick={() => onSetPlayerCount(count)}
+                  className={`rounded-xl border py-2 text-sm font-black transition-all ${playerNames.length === count ? setupActiveOptionClass : setupInactiveOptionClass}`}
+                >
+                  {count}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {(!playAgainstBot ? playerNames : playerNames.slice(0, 1)).map((name, index) => (
+              <PlayerNameField
+                key={index}
+                label={`Joueur ${index + 1}`}
+                value={name}
+                placeholder={`Joueur ${index + 1}`}
+                onChange={(value) => onUpdatePlayerName(index, value)}
+              />
+            ))}
+            {canPlayAgainstBot && playAgainstBot && (
+              <div className="rounded-2xl border border-orange-500/25 bg-orange-500/[0.06] px-4 py-3">
+                <div className="mb-2 flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">
+                  <Bot className="h-4 w-4" />
+                  Adversaire robot
+                </div>
+                <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-lg font-black text-white">
+                  Robot {getBotLevelLabel(X01_BOT_LEVELS, botLevel)}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {canPlayAgainstBot && (
+            <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 p-4">
+              <label className="flex cursor-pointer items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={playAgainstBot}
+                  onChange={(event) => onToggleBot(event.target.checked)}
+                  className="h-5 w-5 rounded border-white/20 bg-white/10 accent-orange-600"
+                />
+                <span className="text-sm font-black uppercase tracking-[0.16em] text-white">
+                  Jouer contre un robot
+                </span>
+              </label>
+
+              {playAgainstBot && (
+                <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+                  {X01_BOT_LEVELS.map((definition) => (
+                    <label
+                      key={definition.level}
+                      className={`cursor-pointer rounded-xl border px-3 py-3 transition-all ${
+                        botLevel === definition.level ? setupActiveOptionClass : setupInactiveOptionClass
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={botLevel === definition.level}
+                        onChange={() => onSetBotLevel(definition.level)}
+                        className="sr-only"
+                      />
+                      <span className="block text-xs font-black uppercase tracking-[0.16em]">
+                        {definition.label}
+                      </span>
+                      <span className="mt-1 block text-[10px] font-bold uppercase leading-tight text-current opacity-75">
+                        {formatX01BotAverageRange(definition)}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+            <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">Joueurs 1 / 2</div>
+            <div className="space-y-3">
+              <PlayerNameField
+                label="Joueur 1"
+                value={team1Names[0]}
+                placeholder="Joueur 1"
+                onChange={(value) => onUpdateTeamName(1, 0, value)}
+                compact
+              />
+              <PlayerNameField
+                label="Joueur 2"
+                value={team1Names[1]}
+                placeholder="Joueur 2"
+                onChange={(value) => onUpdateTeamName(1, 1, value)}
+                compact
+              />
+            </div>
+            <div className="mt-4">
+              <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Qui commence dans ce duo ?</div>
+              <div className="grid grid-cols-2 gap-2">
+                {team1StarterOptions.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => onUpdateTeamStarter('team1', option.id)}
+                    className={`rounded-xl border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] ${teamStarterIds.team1 === option.id ? setupActiveOptionClass : setupInactiveOptionClass}`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+            <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">Joueurs 3 / 4</div>
+            <div className="space-y-3">
+              <PlayerNameField
+                label="Joueur 3"
+                value={team2Names[0]}
+                placeholder="Joueur 3"
+                onChange={(value) => onUpdateTeamName(2, 0, value)}
+                compact
+              />
+              <PlayerNameField
+                label="Joueur 4"
+                value={team2Names[1]}
+                placeholder="Joueur 4"
+                onChange={(value) => onUpdateTeamName(2, 1, value)}
+                compact
+              />
+            </div>
+            <div className="mt-4">
+              <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Qui commence dans ce duo ?</div>
+              <div className="grid grid-cols-2 gap-2">
+                {team2StarterOptions.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => onUpdateTeamStarter('team2', option.id)}
+                    className={`rounded-xl border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] ${teamStarterIds.team2 === option.id ? setupActiveOptionClass : setupInactiveOptionClass}`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/components/game-setup/SetupSummarySection.tsx
+++ b/components/game-setup/SetupSummarySection.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Button } from '../ui/Button';
+import type { SetupSummaryEntry } from '../../src/features/game-setup/setupViewModel';
+import { setupLabelClass, setupSectionClass } from './setupViewStyles';
+
+interface SetupSummarySectionProps {
+  entries: SetupSummaryEntry[];
+  isLaunchBlocked: boolean;
+  onStart: () => void;
+}
+
+export const SetupSummarySection: React.FC<SetupSummarySectionProps> = ({ entries, isLaunchBlocked, onStart }) => (
+  <section className={setupSectionClass}>
+    <label className={setupLabelClass}>Resume Du Match</label>
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+        <div className="mb-2 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Configuration</div>
+        <div className="space-y-2 text-sm text-gray-300">
+          {entries.map((entry) => (
+            <div key={entry.label} className="flex items-center justify-between gap-4">
+              <span>{entry.label}</span>
+              <span className="text-right font-black text-white">{entry.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Button
+        onClick={onStart}
+        disabled={isLaunchBlocked}
+        className="h-16 w-full rounded-2xl text-xl shadow-[0_18px_40px_rgba(234,88,12,0.28)] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none"
+      >
+        Lancer La Partie
+      </Button>
+    </div>
+  </section>
+);

--- a/components/game-setup/setupViewStyles.ts
+++ b/components/game-setup/setupViewStyles.ts
@@ -1,0 +1,4 @@
+export const setupSectionClass = 'rounded-[1.75rem] border border-white/10 bg-white/[0.04] p-5 shadow-[0_16px_40px_rgba(0,0,0,0.2)] backdrop-blur-sm';
+export const setupLabelClass = 'mb-3 block text-[11px] font-black uppercase tracking-[0.28em] text-orange-300';
+export const setupActiveOptionClass = 'bg-gradient-to-r from-orange-600 to-red-600 text-white border-transparent shadow-[0_0_14px_rgba(234,88,12,0.35)]';
+export const setupInactiveOptionClass = 'bg-white/[0.04] border-white/10 text-gray-400 hover:border-orange-500/40 hover:text-white';

--- a/components/game/CapitalKeypad.tsx
+++ b/components/game/CapitalKeypad.tsx
@@ -60,6 +60,8 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
     </Button>
   );
 
+  const getBullLabel = (forcedMultiplier: 1 | 2) => (forcedMultiplier === 2 ? 'BULLE (50)' : 'D-BULLE (25)');
+
   const handleCapitalSubmit = () => {
     const value = parseInt(capitalInput, 10);
     if (Number.isNaN(value) || value < 0 || value > 180) return;
@@ -188,14 +190,14 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
             onClick={() => onDartInput({ value: 25, multiplier: 1 })}
             className="min-h-0 px-2 py-2 text-sm font-black !bg-green-700 !border-green-800 !text-white hover:!bg-green-600 sm:text-lg"
           >
-            BULL
+            D-BULLE (25)
           </Button>
           <Button
             variant="secondary"
             onClick={() => onDartInput({ value: 25, multiplier: 2 })}
             className="min-h-0 px-2 py-2 text-sm font-black !bg-red-600 !border-red-800 !text-white hover:!bg-red-500 sm:text-lg"
           >
-            D-BULL
+            BULLE (50)
           </Button>
         </div>
 
@@ -211,7 +213,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
         <div className="flex min-h-0 flex-1 items-center justify-center rounded-3xl border border-white/10 bg-white/[0.03] p-4">
           <div className="text-center">
             <div className="text-[10px] font-black uppercase tracking-[0.22em] text-gray-500">Objectif</div>
-            <div className="mt-2 text-4xl font-black text-white sm:text-5xl">BULL / D-BULL</div>
+            <div className="mt-2 text-4xl font-black text-white sm:text-5xl">D-BULLE (25) / BULLE (50)</div>
           </div>
         </div>
       </div>
@@ -234,7 +236,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
           ))}
         </div>
         <div className="mt-3 grid h-12 shrink-0 grid-cols-3 gap-2 sm:mt-4 sm:h-14">
-          {renderFixedActionButton('BULL', 25, 2, 'bg-red-600 border-red-800 text-white')}
+          {renderFixedActionButton('BULLE (50)', 25, 2, 'bg-red-600 border-red-800 text-white')}
           <Button variant="secondary" onClick={handleUndoAction} disabled={!canTriggerUndo} className="min-h-0 px-2 py-2 text-sm font-black text-gray-300 sm:text-lg">
             RETOUR
           </Button>
@@ -338,7 +340,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
                   }
                 `}
               >
-                BULL
+                {getBullLabel(multiplier === 2 ? 2 : 1)}
               </Button>
             ) : (
               <div className="col-span-2" />
@@ -452,7 +454,7 @@ export const CapitalKeypad: React.FC<CapitalKeypadProps> = ({ target, onDartInpu
               }
             `}
           >
-            BULL
+            {getBullLabel(multiplier === 2 ? 2 : 1)}
           </Button>
         ) : (
           <div className="col-span-2" />

--- a/components/ui/ChangelogModal.tsx
+++ b/components/ui/ChangelogModal.tsx
@@ -21,51 +21,80 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = ({ onClose }) => {
 
         {/* Content */}
         <div className="p-6 overflow-y-auto custom-scrollbar space-y-8">
-            {/* v1.0.2 */}
+            {/* v1.1 */}
             <div className="relative border-l-2 border-orange-500 pl-4 ml-2">
                 <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-orange-500 border-2 border-gray-900"></div>
                 <div className="flex justify-between items-baseline mb-2">
-                    <span className="text-white font-black text-lg">Version v1.0.2</span>
-                    <span className="text-xs text-gray-500 font-mono">27/04/2026</span>
+                    <span className="text-white font-black text-lg">Version v1.1</span>
+                    <span className="text-xs text-gray-500 font-mono">29/04/2026</span>
                 </div>
 
                 <div className="space-y-4">
                     <div>
-                        <h4 className="text-cyan-500 text-xs font-bold uppercase tracking-widest mb-1">Nouveaux modes de jeu</h4>
+                        <h4 className="text-cyan-500 text-xs font-bold uppercase tracking-widest mb-1">Release open source</h4>
                         <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-cyan-500/50">
-                            <li><b>Gotcha</b> : nouveau mode avec regles metier completes, setup dedie et integration dans le flux de partie.</li>
-                            <li><b>Killer</b> : mode Killer disponible dans la selection et le runtime de partie.</li>
+                            <li><b>Version stable v1.1</b> : perimetre open source clarifie autour du scoring local, des jeux supportes et de l offline-first.</li>
+                            <li><b>Repository public</b> : lien GitHub footer aligne sur le depot officiel Bougnat Darts Counter.</li>
                         </ul>
                     </div>
 
                     <div>
                         <h4 className="text-green-500 text-xs font-bold uppercase tracking-widest mb-1">Ameliorations</h4>
                         <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-green-500/50">
-                            <li><b>Raccourci installation</b> : bouton "Ajouter a l'ecran d'accueil" sur la page principale.</li>
-                            <li><b>Stats X01</b> : label "CHECKOUT" plus explicite pour les sorties.</li>
-                            <li><b>Score layout</b> : affichage du score resilient au zoom systeme de l'OS, plus de debordement sur petit ecran.</li>
-                            <li><b>Performance</b> : reactivite des boutons amelioree (reduction du delai de reponse).</li>
+                            <li><b>Voice scoring X01</b> : sessions vocales mieux bornees, incidents runtime plus lisibles et propositions mieux arbitrees.</li>
+                            <li><b>Architecture</b> : refactors valides sur Setup, Triathlon, Capital, Cricket et flux Deepgram pour une base plus maintenable.</li>
+                            <li><b>React 19</b> : runtime frontend aligne sur la nouvelle base React sans reouvrir le scope produit.</li>
+                            <li><b>Stats X01</b> : taux de checkout Double Out recalibre sur les vraies tentatives de finish.</li>
                         </ul>
                     </div>
 
                     <div>
                         <h4 className="text-yellow-500 text-xs font-bold uppercase tracking-widest mb-1">Corrections</h4>
                         <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-yellow-500/50">
-                            <li>Fix scroll parasite lors de la selection de partie sur mobile.</li>
-                            <li>Compatibilite iOS 12 retablie pour les anciens iPad.</li>
+                            <li>Suppression du faux contrat d'environnement tournoi cote runtime supporte.</li>
+                            <li>Mode bot <b>PRO</b> affiche maintenant <b>+ de 85 de moyenne</b> et les bots ont des prenoms aleatoires.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            {/* v1.0.2 */}
+            <div className="relative border-l-2 border-gray-700 pl-4 ml-2">
+                <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-700 border-2 border-gray-900"></div>
+                <div className="flex justify-between items-baseline mb-2">
+                    <span className="text-gray-400 font-black text-lg">Version v1.0.2</span>
+                    <span className="text-xs text-gray-600 font-mono">27/04/2026</span>
+                </div>
+                
+                <div className="space-y-4">
+                    <div>
+                        <h4 className="text-cyan-500 text-xs font-bold uppercase tracking-widest mb-1">Fonctionnalites</h4>
+                        <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-cyan-500/50">
+                            <li><b>Gotcha</b> : nouveau mode avec regles metier completes, setup dedie et integration dans le flux de partie.</li>
+                            <li><b>Killer</b> : mode Killer disponible dans la selection et le runtime de partie.</li>
+                        </ul>
+                    </div>
+                    
+                    <div>
+                        <h4 className="text-green-500 text-xs font-bold uppercase tracking-widest mb-1">Stabilisation</h4>
+                        <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-green-500/50">
+                            <li><b>Raccourci installation</b> : bouton "Ajouter a l'ecran d'accueil" sur la page principale.</li>
+                            <li><b>Stats X01</b> : label "CHECKOUT" plus explicite pour les sorties.</li>
+                            <li><b>Score layout</b> : affichage du score resilient au zoom systeme de l'OS, plus de debordement sur petit ecran.</li>
+                            <li><b>Performance</b> : reactivite des boutons amelioree.</li>
                         </ul>
                     </div>
                 </div>
             </div>
 
             {/* v1.0.1 */}
-            <div className="relative border-l-2 border-gray-700 pl-4 ml-2">
-                <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-700 border-2 border-gray-900"></div>
+            <div className="relative border-l-2 border-gray-800 pl-4 ml-2">
+                <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-gray-800 border-2 border-gray-900"></div>
                 <div className="flex justify-between items-baseline mb-2">
-                    <span className="text-gray-400 font-black text-lg">Version v1.0.1</span>
+                    <span className="text-gray-500 font-black text-lg">Version v1.0.1</span>
                     <span className="text-xs text-gray-600 font-mono">24/04/2026</span>
                 </div>
-                
+
                 <div className="space-y-4">
                     <div>
                         <h4 className="text-cyan-500 text-xs font-bold uppercase tracking-widest mb-1">Fonctionnalites</h4>
@@ -77,13 +106,13 @@ export const ChangelogModal: React.FC<ChangelogModalProps> = ({ onClose }) => {
                             <li><b>Assistance vocale IA X01</b> : aide a la saisie conservee avec une interface plus stable.</li>
                         </ul>
                     </div>
-                    
+
                     <div>
                         <h4 className="text-green-500 text-xs font-bold uppercase tracking-widest mb-1">Stabilisation</h4>
                         <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside marker:text-green-500/50">
                             <li>Amelioration de la securite des flux locaux et reduction des surfaces inutiles.</li>
                             <li>Code simplifie et mieux decoupe pour faciliter la lisibilite et la maintenance.</li>
-                            <li>Refonte progressive de l’architecture pour preparer les prochaines evolutions sans casser l’existant.</li>
+                            <li>Refonte progressive de l architecture pour preparer les prochaines evolutions sans casser l existant.</li>
                         </ul>
                     </div>
                 </div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,23 +151,28 @@ En pratique, la seule integration reseau supportee dans le runtime `v1.0.2` rest
 
 ## Decision v1.0.2
 
-Le refactoring `v1.0.2` decoupe les god objects identifies :
+Le refactoring `v1.0.2` puis sa continuation `v1.0.3` decoupent les god objects identifies :
 
 - `setupModel.ts` : separation reducer d etat / helpers de presentation → `setupPresentation.ts`
 - `App.tsx` : extraction des handlers cycle de vie → `useGameLifecycle.ts`
 - `App.tsx` : instance analytics partagee → `analyticsInstance.ts`
 - `MatchView.tsx` : timer side-effect → `useMatchTimer.ts`
 - `MatchView.tsx` : shortcuts state + handlers → `useMatchShortcuts.ts`
+- `SetupView.tsx` : configuration joueurs + resume → `SetupPlayersSection.tsx`, `SetupSummarySection.tsx`, `setupViewModel.ts`
+- `useDeepgramStreaming.ts` : buffer/transcript/logging/audio/socket → `voiceStreamingModel.ts`, `voiceStreamingLogger.ts`, `audioContextManager.ts`, `deepgramConnectionManager.ts`
+- `utils/triathlonScoring.ts` : types/regles → `src/domain/triathlon/`
+- `CapitalGameView.tsx` : reducer + snapshots → `src/features/capital/capitalGameModel.ts`
+- `CricketGameView.tsx` : competiteurs + snapshots + resume → `src/features/cricket/cricketGameModel.ts`
 
-Resultat: −402 lignes sur les fichiers centraux, 5 nouveaux modules a responsabilite unique, 0 changement fonctionnel, 120/120 tests unitaires conserves.
+Resultat: baisse continue de la taille des fichiers centraux, 0 changement fonctionnel, et couverture unitaire maintenue sur les extractions pures.
 
 Fichiers restant a decouvper (backlog):
 
-- `views/SetupView.tsx` (770 lignes) : extraire `PlayerConfigSection`, `GameRulesSection`, `SetupSummary`
-- `src/features/x01/voice/useDeepgramStreaming.ts` (555 lignes) : extraire `audioContextManager`, `deepgramConnectionManager`, `pcmBufferManager`
-- `utils/triathlonScoring.ts` (572 lignes) : types domaine → `src/domain/triathlon/`, regles → `src/domain/triathlon/triathlonScoringRules.ts`
-- `views/CapitalGameView.tsx` (500 lignes) : extraire hooks metier Capital
-- `views/CricketGameView.tsx` (475 lignes) : extraire hooks metier Cricket
+- `views/SetupView.tsx` : finaliser l'extraction de `GameRulesSection` si le flux setup bouge encore
+- `src/features/x01/voice/useDeepgramStreaming.ts` : extraire les callbacks evenementiels si le flux vocal continue de grossir
+- `utils/triathlonScoring.ts` : pousser les calculateurs d'epreuves dans `src/domain/triathlon/` si les regles deviennent plus riches
+- `views/CapitalGameView.tsx` : extraire le rendu winner/stats si d'autres variantes d'UI arrivent
+- `views/CricketGameView.tsx` : extraire un hook d'orchestration de tour si le flux cricket continue de grossir
 
 ## Decision v1.0.1
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Le repo porte le moteur de scorage, les modes de jeu, les sessions locales et le
 
 Il ne porte pas la source de vérité métier pour l organisation de tournoi, les profils distants ou les statistiques cloud.
 
-La base `v1.0.2` est considerée stable pour un usage open source centre sur le scorage local. Les chantiers restants relevent de clarifications ou de decoupes internes, pas d un elargissement de perimetre.
+La base `v1.1` est la cible stable open source pour le scorage local. Les chantiers restants relevent d un durcissement release, pas d un elargissement de perimetre.
 
 ## Core Principles
 
@@ -71,24 +71,24 @@ src/
   app/
     appShell.ts          — session persistence, screen guards
     useAppScreenHistory.ts
-    useGameLifecycle.ts  — [v1.0.2] game finish/rematch/exit handlers
+    useGameLifecycle.ts  — [v1.1] game finish/rematch/exit handlers
   domain/
   application/
   infrastructure/
   features/
     game-setup/
       setupModel.ts        — reducer, state, factories
-      setupPresentation.ts — [v1.0.2] labels, rule descriptions, game names
+      setupPresentation.ts — [v1.1] labels, rule descriptions, game names
     x01/
       scoring/
       voice/
       hooks/
-        useMatchTimer.ts    — [v1.0.2] elapsed timer + live clock
-        useMatchShortcuts.ts — [v1.0.2] shortcut state + handlers
+        useMatchTimer.ts    — [v1.1] elapsed timer + live clock
+        useMatchShortcuts.ts — [v1.1] shortcut state + handlers
     triathlon/
   lib/
     env.ts
-    analyticsInstance.ts — [v1.0.2] analytics port singleton
+    analyticsInstance.ts — [v1.1] analytics port singleton
   views/
   components/
   shared/
@@ -147,11 +147,11 @@ The supported open source repo does not own:
 - tournament orchestration
 - proprietary business persistence
 
-En pratique, la seule integration reseau supportee dans le runtime `v1.0.2` reste le voice scoring optionnel via Deepgram, avec fallback manuel obligatoire et sans dependance gameplay au reseau.
+En pratique, la seule integration reseau supportee dans le runtime `v1.1` reste le voice scoring optionnel via Deepgram, avec fallback manuel obligatoire et sans dependance gameplay au reseau.
 
-## Decision v1.0.2
+## Decision v1.1
 
-Le refactoring `v1.0.2` puis sa continuation `v1.0.3` decoupent les god objects identifies :
+La consolidation `v1.1` confirme et etend les extractions pragmatiques engagees sur les fichiers centraux :
 
 - `setupModel.ts` : separation reducer d etat / helpers de presentation → `setupPresentation.ts`
 - `App.tsx` : extraction des handlers cycle de vie → `useGameLifecycle.ts`
@@ -160,19 +160,20 @@ Le refactoring `v1.0.2` puis sa continuation `v1.0.3` decoupent les god objects 
 - `MatchView.tsx` : shortcuts state + handlers → `useMatchShortcuts.ts`
 - `SetupView.tsx` : configuration joueurs + resume → `SetupPlayersSection.tsx`, `SetupSummarySection.tsx`, `setupViewModel.ts`
 - `useDeepgramStreaming.ts` : buffer/transcript/logging/audio/socket → `voiceStreamingModel.ts`, `voiceStreamingLogger.ts`, `audioContextManager.ts`, `deepgramConnectionManager.ts`
+- `useDeepgramStreaming.ts` : session attempt, issue runtime et arbitrage proposition → `voiceSessionModel.ts`, `voiceProposalModel.ts`
 - `utils/triathlonScoring.ts` : types/regles → `src/domain/triathlon/`
 - `CapitalGameView.tsx` : reducer + snapshots → `src/features/capital/capitalGameModel.ts`
 - `CricketGameView.tsx` : competiteurs + snapshots + resume → `src/features/cricket/cricketGameModel.ts`
+- `App.tsx` : pageviews SPA Vercel et flags coherents sans remonter Vercel dans le domaine
+- runtime/frontend : migration `React 19` sans reouvrir le scope produit
 
 Resultat: baisse continue de la taille des fichiers centraux, 0 changement fonctionnel, et couverture unitaire maintenue sur les extractions pures.
 
-Fichiers restant a decouvper (backlog):
+Backlog `v1.1+` volontairement limite :
 
-- `views/SetupView.tsx` : finaliser l'extraction de `GameRulesSection` si le flux setup bouge encore
-- `src/features/x01/voice/useDeepgramStreaming.ts` : extraire les callbacks evenementiels si le flux vocal continue de grossir
-- `utils/triathlonScoring.ts` : pousser les calculateurs d'epreuves dans `src/domain/triathlon/` si les regles deviennent plus riches
-- `views/CapitalGameView.tsx` : extraire le rendu winner/stats si d'autres variantes d'UI arrivent
-- `views/CricketGameView.tsx` : extraire un hook d'orchestration de tour si le flux cricket continue de grossir
+- `views/SetupView.tsx` : extractions UI additionnelles uniquement si le flux setup regrossit
+- `src/features/x01/voice/useDeepgramStreaming.ts` : callbacks supplementaires seulement si le protocole voix s'elargit
+- `views/CapitalGameView.tsx` et `views/CricketGameView.tsx` : extractions UI futures seulement en cas d'evolution produit concrete
 
 ## Decision v1.0.1
 
@@ -186,9 +187,10 @@ The `v1.0.1` release locks the current runtime to:
 
 The repository intentionally avoids carrying proprietary product logic in runtime code.
 
-## Release Controls v1.0.1
+## Release Controls v1.1
 
 - promotion `preprod` et `production` bloquee si `DEEPGRAM_API_KEY` ou `DEEPGRAM_PROJECT_ID` manque
 - promotion `preprod` et `production` bloquee si le projet Deepgram cible n est pas accessible (`GET /v1/projects/{project_id}`)
 - quality gate basee sur `lint`, `typecheck`, `test:unit`, `build`
 - smoke E2E conserve pour proteger les flux critiques de scoring
+- aucun contrat d environnement tournament-specifique n est requis par le runtime supporte

--- a/docs/audit-security-vercel-performance-2026-04-24.md
+++ b/docs/audit-security-vercel-performance-2026-04-24.md
@@ -16,7 +16,10 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 | `vercel.json` | Moyenne | Build Vercel sensible aux differences d'outil d'installation | Corrige: installation npm explicite et package manager declare |
 | `package-lock.json` | Moyenne | `npm audit` signalait `brace-expansion` en dependance dev | Corrige: `npm audit fix`, audit a 0 vulnerabilite |
 | `App.tsx`, `index.tsx` | Basse | Bundle initial et logs runtime trop bavards | Corrige: lazy loading des ecrans setup/match, loader plus sobre, logs SW limites au debug |
-| `views/MatchView.tsx`, `views/SetupView.tsx` | Basse | Composants volumineux | Action prudente: chargement a la demande. Extraction interne a planifier plus tard si evolution fonctionnelle |
+| `views/MatchView.tsx`, `views/SetupView.tsx` | Basse | Composants volumineux | Partiellement corrige: `SetupView` redecoupee en sections dediees; poursuivre seulement si le flux setup change encore |
+| `src/features/x01/voice/useDeepgramStreaming.ts` | Basse | Hook dense, logs debug verbeux | Partiellement corrige: managers audio/socket extraits, logs debug bornes au dev; restent surtout les callbacks evenements |
+| `views/CapitalGameView.tsx`, `views/CricketGameView.tsx` | Basse | Ecrans de match avec logique de tour et snapshots | Partiellement corrige: state machines et helpers de resume extraits vers `src/features/*/` |
+| `utils/triathlonScoring.ts` | Basse | Utilitaire dense mélangeant domaine et règles | Partiellement corrige: types et règles migrés dans `src/domain/triathlon/` |
 | `src/styles/tailwind.css` | Basse | CSS global limite, pas de surcharge majeure detectee | Pas de refonte recommandee |
 
 ## Audit Vercel
@@ -32,7 +35,7 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 
 ## Dette et risques residuels
 
-- `MatchView.tsx`, `SetupView.tsx`, `CapitalGameView.tsx` et `CricketGameView.tsx` restent gros. Les decouper necessite une passe fonctionnelle plus longue avec tests E2E dedies.
+- `MatchView.tsx` reste gros. `CapitalGameView.tsx`, `CricketGameView.tsx` et `utils/triathlonScoring.ts` ont ete partiellement assainis mais gardent encore du wiring qui gagnerait a etre extrait avec des tests E2E dedies.
 - Le rate limiting Edge en memoire est volontairement simple; il reduit l'abus opportuniste mais n'est pas global entre regions/instances.
 - Les donnees de session restent en stockage local/IndexedDB par design offline-first; ne pas y ajouter de secret ou token longue duree.
 
@@ -44,6 +47,10 @@ Priorite traitee: durcissement de `/api/deepgram/token`, contrat d'environnement
 - Build Vercel aligne sur npm avec configuration explicite.
 - Lazy loading des ecrans de scorage et setup.
 - Logs runtime reduits hors debug.
+- Decoupage de `SetupView` en sections UI dediees + helper metier de composition.
+- Extraction des helpers purs de `useDeepgramStreaming` et suppression des logs payload vocaux bruts cote client.
+- Extraction du domaine triathlon (types + regles) hors de `utils/triathlonScoring.ts`.
+- Extraction des state machines / snapshots Capital et Cricket dans des modules feature dedies.
 
 ## Verifications executees
 

--- a/docs/product-scope.md
+++ b/docs/product-scope.md
@@ -39,9 +39,6 @@ Cette release stable couvre uniquement le gameplay local, le scoring, les jeux s
 
 Le voice scoring reste un module optionnel: l application doit rester jouable en scorage manuel si Deepgram est indisponible.
 
-`VITE_TOURNAMENT_API_URL` est un point d integration optionnel et documenté. Aucun gameplay local n en depend.
-Il est prévu pour un couplage léger contractuel avec `Bougnat_Darts_Tournaments` — sans fuite de logique propriétaire.
-
 Toute integration plus large avec un systeme maitre doit se faire :
 
 - par contrats explicites

--- a/docs/product-scope.md
+++ b/docs/product-scope.md
@@ -22,7 +22,7 @@
 - orchestration organisateur
 - persistance backend metier
 
-## Jeux supportes en v1.0.2
+## Jeux supportes en v1.1
 
 - **X01** (501, 301, 701 — Legs ou Sets, Single/Double/Master Out, mode bot IA)
 - **Cricket**
@@ -33,7 +33,7 @@
 
 ## Frontiere produit
 
-Le repo est publie comme une application open source de scoring stable en `v1.0.2`.
+Le repo est aligne comme une application open source de scoring stable en `v1.1`.
 
 Cette release stable couvre uniquement le gameplay local, le scoring, les jeux supportes, le voice scoring optionnel, les sessions locales et la logique offline-first.
 
@@ -57,4 +57,4 @@ Toute integration plus large avec un systeme maitre doit se faire :
 - les profils distants
 - les integrations backend explicites
 
-La frontiere de release `v1.0.2` impose que cette relation reste contractuelle, sans dependance runtime obligatoire du gameplay local vers le systeme maitre.
+La frontiere de release `v1.1` impose que cette relation reste contractuelle, sans dependance runtime obligatoire du gameplay local vers le systeme maitre.

--- a/docs/release/react-19-validation-matrix.md
+++ b/docs/release/react-19-validation-matrix.md
@@ -1,0 +1,47 @@
+# React 19 validation matrix
+
+## Scope
+
+- Runtime target: React 19.2.0 / React DOM 19.2.0
+- Validation target: local, Playwright, preview Vercel, legacy browser spot-checks
+- Repository: `Bougnat_darts_counter`
+
+## Automated checks
+
+| Check | Command | Status | Notes |
+| --- | --- | --- | --- |
+| TypeScript | `npm run typecheck` | done | passes under React 19 |
+| Lint | `npm run lint` | done | no new lint issue |
+| Unit tests | `npm run test:unit` | done | 28 files, 128 tests passed |
+| Production build | `npm run build` | done | Vite production build passes |
+| CI baseline | `npm run ci:check` | done | env, guard, lint, typecheck, unit, build all pass |
+| E2E smoke | `npm run test:e2e` | done | Playwright green after Triathlon smoke update |
+
+## Manual validation matrix
+
+| Area | Scenario | Owner | Status | Notes |
+| --- | --- | --- | --- | --- |
+| X01 | lancer une partie, jouer quelques tours, finish, rematch | product/qa | pending | verifier scoreboard, keypad, fin de match |
+| Cricket | lancer une partie, fermer des segments, quitter | product/qa | pending | verifier grille et keypad |
+| Capital | lancer une partie et verifier l objectif courant | product/qa | pending | verifier les labels centre/bull |
+| Gotcha | lancer une partie et verifier le layout tablette | product/qa | pending | verifier clavier, scroll et overlay |
+| Killer | lancer une partie et verifier l entree en match | product/qa | pending | verifier elimination et retour |
+| Triathlon | lancer une partie, overlay starter, enchainement des phases | product/qa | pending | verifier que l ancien tir a la bulle n existe plus |
+| Voice scoring | start/stop micro, navigation pendant ecoute, timeout | product/qa | pending | cible Deepgram + cleanup hooks |
+| Session restore | recharger pendant une partie et restaurer l etat | product/qa | pending | verifier persistance locale |
+| PWA/update | install, refresh, update lifecycle | product/qa | pending | verifier service worker et blocage live update |
+| Analytics | verifier events/pages/flags sur preview | product/qa | pending | cible Vercel preview avec observability active |
+| Legacy Safari/iOS | smoke test sur Safari/iOS ancien ou BrowserStack | product/qa | pending | verifier compat legacy |
+| Tablet landscape | smoke visuel sur tablette paysage | product/qa | pending | verifier layouts critiques |
+
+## Rollout decision gates
+
+- preview Vercel validee sans regression visible
+- aucun bug bloquant sur scoring vocal, session restore ou PWA
+- smoke acceptable sur Safari/iOS legacy ou equivalent
+- validation produit sur les 6 modes de jeu
+
+## Notes
+
+- Le seul ecart automatise detecte pendant la migration a ete un test Playwright Triathlon obsolet e qui attendait encore l ancien ecran `Tir a la bulle`.
+- Le flux reel utilise deja `StartingPlayerOverlay`; le test a ete aligne sur le comportement metier courant.

--- a/docs/release/v1.1-coverage-map.md
+++ b/docs/release/v1.1-coverage-map.md
@@ -1,0 +1,153 @@
+# Coverage Map v1.1
+
+Format canonique: `Spec -> Code -> Tests -> Issues -> Status`
+
+## Zones couvertes
+
+- `spec:counter/scoring-access-modes`
+	- Code: `src/app/appShell.ts`, `src/application/scoring/`, `src/domain/`
+	- Tests: `tests/unit/app/appShell.test.ts`, `tests/unit/x01/*.test.ts`, `tests/unit/gameLogic.test.ts`
+	- Issues: `#94`
+	- Status: `couvert`
+
+- `spec:counter/offline-scoring-terminal-foundation`
+	- Code: `src/application/scoring/matchLifecycle.ts`, `src/infrastructure/local/IndexedDBSessionRepository.ts`, `src/features/game-setup/setupModel.ts`, `src/features/game-setup/setupViewModel.ts`
+	- Tests: `tests/unit/application/matchLifecycle.test.ts`, `tests/unit/application/indexedDbSessionRepository.test.ts`, `tests/unit/gameSetup/setupModel.test.ts`, `tests/unit/gameSetup/setupViewModel.test.ts`
+	- Issues: `#97`
+	- Status: `couvert`
+
+- `spec:counter/voice-scoring-reliability`
+	- Code: `src/features/x01/voice/`, `views/MatchView.tsx`
+	- Tests: `tests/unit/dartsSpeechParser.test.ts`, `tests/unit/x01/voicePcm.test.ts`, `tests/unit/x01/voiceStreamingModel.test.ts`, `tests/unit/x01/voiceSessionModel.test.ts`, `tests/unit/x01/voiceProposalModel.test.ts`
+	- Issues: `#96`
+	- Status: `couvert (voice optionnel, fallback manuel obligatoire)`
+
+- `spec:counter/voice-token-provisioning-hardening`
+	- Code: `lib/deepgramToken.ts`, `api/deepgram/token.ts`, `scripts/deployment-check.mjs`
+	- Tests: `tests/unit/lib/deepgramToken.test.ts`, `tests/unit/api/deepgramTokenRoute.test.ts`
+	- Issues: `#96`
+	- Status: `couvert`
+
+- `spec:counter/arch-single-responsibility-split`
+	- Code: `views/SetupView.tsx`, `src/features/game-setup/setupViewModel.ts`, `src/domain/triathlon/`, `src/features/capital/capitalGameModel.ts`, `src/features/cricket/cricketGameModel.ts`, `src/features/x01/voice/useDeepgramStreaming.ts`
+	- Tests: `tests/unit/gameSetup/setupViewModel.test.ts`, `tests/unit/triathlonScoring.test.ts`, `tests/unit/capitalGameModel.test.ts`, `tests/unit/cricketGameModel.test.ts`, `tests/unit/x01/voiceSessionModel.test.ts`, `tests/unit/x01/voiceProposalModel.test.ts`
+	- Issues: `#99`
+	- Status: `couvert`
+
+- `spec:counter/x01-double-out-checkout-rate`
+	- Code: `src/application/scoring/matchStats.ts`, `src/presentation/stats/statsPresenter.fr.ts`
+	- Tests: `tests/unit/application/matchStats.test.ts`, `tests/unit/presentation/stats/statsPresenter.fr.test.ts`
+	- Issues: `#94`, `#99`
+	- Status: `couvert`
+
+- `spec:counter/vercel-spa-pageviews-and-flags`
+	- Code: `App.tsx`, `src/application/observability/analyticsUseCases.ts`, `src/domain/observability/analyticsDomain.ts`, `src/infrastructure/observability/vercelAnalyticsAdapter.ts`
+	- Tests: `tests/unit/observability/analyticsApplication.test.ts`, `tests/unit/observability/analyticsDomain.test.ts`
+	- Issues: `#98`, `#99`
+	- Status: `couvert`
+
+- `spec:counter/react-19-migration`
+	- Code: `package.json`, `package-lock.json`, `index.tsx`, `App.tsx`, `src/app/**`, `src/lib/**`
+	- Tests: `npm run ci:check`, `tests/e2e/*.smoke.spec.ts`
+	- Issues: `#99`
+	- Status: `couvert`
+
+- `spec:counter/release-v1.1-stabilization`
+	- Code: `package.json`, `README.md`, `docs/architecture.md`, `docs/product-scope.md`, `docs/technical.md`, `docs/specifications.md`, `docs/release/v1.1.md`, `docs/release/v1.1-coverage-map.md`, `views/HomeView.tsx`, `components/ui/ChangelogModal.tsx`
+	- Tests: `npm run ci:check`, `npm run test:e2e`, `npm run preprod:check`, `npm run production:check`
+	- Issues: `#103`
+	- Status: `couvert sur develop, branche release encore a valider`
+
+## Zones partiellement couvertes
+
+- `spec:counter/ui-scoreboard-layout-consistency`
+	- Code: `views/MatchView.tsx`, `components/game/Keypad.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#95`
+	- Status: `partiel (couverture smoke E2E)`
+
+- `spec:counter/x01-keypad-digit-scale`
+	- Code: `components/game/Keypad.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#94`
+	- Status: `partiel (protege en E2E)`
+
+- `spec:counter/ios12-compatibility`
+	- Code: `vite.config.ts`, `sw.js`
+	- Tests: `tests/unit/infrastructure/legacySupport.test.ts`, `npm run build`
+	- Issues: `#98`
+	- Status: `partiel (pas de campagne device reelle automatisee)`
+
+- `spec:counter/score-layout-font-scale-resilience`
+	- Code: `views/MatchView.tsx`
+	- Tests: `tests/e2e/gameplay-entry.smoke.spec.ts`
+	- Issues: `#95`
+	- Status: `partiel (protege en smoke E2E)`
+
+## Zones volontairement hors perimetre
+
+- backend metier
+- authentification metier avancee
+- profils distants persistants
+- statistiques cloud consolidees
+- logique tournoi
+- persistance backend metier
+- couplage proprietaire obligatoire avec `Bougnat_Darts_Tournaments`
+
+Status: `hors scope assume`, destine a `Bougnat_Darts_Tournaments` ou a des integrations contractuelles futures.
+
+## Tests -> Specs
+
+| Fichier test | Spec(s) couvertes |
+|---|---|
+| `tests/unit/gameSetup/setupModel.test.ts` | 002, 015, 016 |
+| `tests/unit/gameSetup/setupViewModel.test.ts` | 002, 022 |
+| `tests/unit/x01/scoringDomain.test.ts` | 001 |
+| `tests/unit/x01/matchScoring.test.ts` | 001 |
+| `tests/unit/x01/matchPlayerScore.test.ts` | 001 |
+| `tests/unit/x01/x01BotTurn.test.ts` | 001, 016 |
+| `tests/unit/x01/x01BotDefinition.test.ts` | 016 |
+| `tests/unit/x01/botVictoryPreview.test.ts` | 016 |
+| `tests/unit/application/matchLifecycle.test.ts` | 001, 002 |
+| `tests/unit/application/scoringUseCases.test.ts` | 001 |
+| `tests/unit/application/matchStats.test.ts` | 001, 013, 023 |
+| `tests/unit/application/indexedDbSessionRepository.test.ts` | 010 |
+| `tests/unit/app/appShell.test.ts` | 001, 022 |
+| `tests/unit/app/persistAppSession.test.ts` | 010, 020 |
+| `tests/unit/appInstall/installPromptModel.test.ts` | 011 |
+| `tests/unit/observability/analyticsDomain.test.ts` | 012, 024 |
+| `tests/unit/observability/analyticsApplication.test.ts` | 012, 024 |
+| `tests/unit/presentation/stats/statsPresenter.fr.test.ts` | 013, 023 |
+| `tests/unit/presentation/stats/statsLabels.fr.test.ts` | 013 |
+| `tests/unit/cricketLogic.test.ts` | 001 |
+| `tests/unit/cricketGameModel.test.ts` | 022 |
+| `tests/unit/killerLogic.test.ts` | 017 |
+| `tests/unit/gotchaLogic.test.ts` | 019 |
+| `tests/unit/capitalLogic.test.ts` | 001 |
+| `tests/unit/capitalGameModel.test.ts` | 022 |
+| `tests/unit/triathlonScoring.test.ts` | 001, 022 |
+| `tests/unit/gameLogic.test.ts` | 001 |
+| `tests/unit/dartsSpeechParser.test.ts` | 003 |
+| `tests/unit/lib/deepgramToken.test.ts` | 003, 006 |
+| `tests/unit/api/deepgramTokenRoute.test.ts` | 003, 006 |
+| `tests/unit/x01/voicePcm.test.ts` | 003 |
+| `tests/unit/x01/voiceStreamingModel.test.ts` | 003, 022 |
+| `tests/unit/x01/voiceSessionModel.test.ts` | 003, 022 |
+| `tests/unit/x01/voiceProposalModel.test.ts` | 003, 022 |
+| `tests/unit/infrastructure/legacySupport.test.ts` | 018 |
+| `tests/e2e/app.smoke.spec.ts` | 001, 007, 026 |
+| `tests/e2e/gameplay-entry.smoke.spec.ts` | 001, 005, 014, 021 |
+| `tests/e2e/navigation.smoke.spec.ts` | 001, 008 |
+| `tests/e2e/completion.smoke.spec.ts` | 001, 008 |
+
+## Issues -> Specs -> Status
+
+| Issue ou bucket | Specs rattachees | Statut |
+|---|---|---|
+| `#94` Core Scoring Engine | 001, 014, 015, 016, 023 | Bucket actif `M1` |
+| `#95` Game Modes Stability | 005, 017, 019, 021 | Bucket actif `M2` |
+| `#96` Voice Scoring Reliability | 003, 006 | Bucket actif `M3` |
+| `#97` Local Session Persistence | 002, 010, 020 | Bucket actif `M4` |
+| `#98` Offline-first UX | 008, 011, 018, 024 | Bucket actif `M5` |
+| `#99` Architecture & Technical Cleanup | 012, 013, 022, 023, 024, 025 | Bucket actif `M6` |
+| `#103` Open Source Release v1.1 | 026 | Pilotage release `M9` |

--- a/docs/release/v1.1.md
+++ b/docs/release/v1.1.md
@@ -1,0 +1,58 @@
+# Release v1.1
+
+## Statut
+
+- cible stable open source
+- centree sur le scorage, les jeux supportes et l offline-first
+- version package: `1.1.0`
+- issue de pilotage release: `#103`
+- milestone de release: `M9: Open Source Release v1.1`
+
+## Resume fonctionnel
+
+### Gameplay consolide
+
+- `X01`, `501 Double Out`, `Cricket`, `Capital`, `Triathlon`, `Killer` et `Gotcha` restent dans le perimetre supporte
+- le voice scoring `X01` reste optionnel et conserve un fallback manuel obligatoire
+- la reprise locale, l historique local et l experience offline-first restent au coeur du runtime supporte
+
+### Durcissements visibles
+
+- le voice scoring borne mieux chaque tentative de prise de parole et distingue explicitement les incidents runtime utiles a l utilisateur
+- l arbitrage des propositions vocales `X01` evite les prefills ambigus et garde la validation finale dans le flux manuel existant
+- le bot `X01` a un nom aleatoire lisible et une communication `PRO` coherente avec le seuil `+ de 85 de moyenne`
+- la page d accueil pointe maintenant vers le repository GitHub public et garde un changelog utilisateur visible depuis le footer
+
+## Resume technique
+
+- `spec:counter/arch-single-responsibility-split` poursuit la decoupe pragmatique de `SetupView`, `Triathlon`, `Capital`, `Cricket` et du flux Deepgram
+- `spec:counter/x01-double-out-checkout-rate` redefinit le taux de checkout `Double Out` sur des tentatives reelles
+- `spec:counter/vercel-spa-pageviews-and-flags` aligne les pageviews SPA et les flags analytics sur les ecrans logiques du produit
+- `spec:counter/react-19-migration` fait passer la base frontend sur `React 19`
+- `spec:counter/release-v1.1-stabilization` aligne version, documentation, coverage map, issue release et gouvernance Git
+- le contrat d environnement `VITE_TOURNAMENT_API_URL` est retire du runtime supporte pour clarifier la frontiere open source
+
+## Verification develop
+
+- `npm run ci:check`: OK
+- `35` fichiers de tests unitaires passes
+- `149` tests unitaires passes
+- `npm run build`: OK
+
+La validation finale `release/1.1` reste a rejouer avant le tag `v1.1` et la PR vers `main`.
+
+## Hors perimetre confirme
+
+- backend metier proprietaire
+- authentification riche
+- profils distants persistants
+- statistiques cloud consolidees
+- logique tournoi avancee
+- persistance metier distante
+- couplage runtime obligatoire avec `Bougnat_Darts_Tournaments`
+
+## Limitations connues
+
+- le voice scoring depend d un service externe optionnel
+- les checks `preprod` et `production` exigent des variables Deepgram correctement renseignees dans les environnements cibles
+- les smoke E2E reposent sur un navigateur Chromium disponible sur la machine ou le runner

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -228,9 +228,10 @@ Principes :
 
 Fichiers cibles du prochain cycle de decoupe :
 
-- `views/SetupView.tsx` : extraire `PlayerConfigSection`, `GameRulesSection`, `SetupSummary`
-- `src/features/x01/voice/useDeepgramStreaming.ts` : extraire `audioContextManager`, `deepgramConnectionManager`, `pcmBufferManager`
-- `utils/triathlonScoring.ts` : types domaine → `src/domain/triathlon/`, regles → `src/domain/triathlon/triathlonScoringRules.ts`
+- `views/SetupView.tsx` : extraire encore `GameRulesSection` si la configuration jeu continue d'evoluer
+- `src/features/x01/voice/useDeepgramStreaming.ts` : extraire les callbacks evenementiels si le flux vocal continue d'evoluer
+- `views/CapitalGameView.tsx` : sortir le rendu winner/stats si de nouvelles variantes arrivent
+- `views/CricketGameView.tsx` : sortir un hook de tour si le flux cricket grandit encore
 
 ## 9. Environment Model
 

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -21,7 +21,7 @@ Le scope courant couvre :
 - historique local
 - assistance vocale `X01`
 
-Les fonctions sociales, cloud et backend metier sont hors perimetre de `v1.0.2`.
+Les fonctions sociales, cloud et backend metier sont hors perimetre de `v1.1`.
 Elles ne font plus partie du runtime supporte de l application open source.
 
 ## 1.bis Specification Discipline
@@ -125,33 +125,39 @@ Principales zones frontend :
 - `src/app/` : garde-fous d environnements, session locale et cycle de vie des jeux
   - `appShell.ts` : session persistence, screen guards
   - `useAppScreenHistory.ts` : historique ecrans pour le bouton retour
-  - `useGameLifecycle.ts` : handlers de fin de partie, rematch et sortie de jeu [v1.0.2]
+  - `useGameLifecycle.ts` : handlers de fin de partie, rematch et sortie de jeu [v1.1]
 - `src/application/` : use cases et ports
 - `src/infrastructure/` : persistence locale et adapters
 - `src/features/game-setup/` : reducer de configuration, factories joueurs/config
   - `setupModel.ts` : reducer, etat, factories
-  - `setupPresentation.ts` : labels, descriptions de regles, noms de jeux [v1.0.2]
+  - `setupPresentation.ts` : labels, descriptions de regles, noms de jeux [v1.1]
 - `src/features/x01/voice/` : moteur vocal `X01`
-- `src/features/x01/hooks/` : hooks metier extraits des vues [v1.0.2]
+- `src/features/x01/hooks/` : hooks metier extraits des vues [v1.1]
   - `useMatchTimer.ts` : chronometre et horloge
   - `useMatchShortcuts.ts` : raccourcis score personnalisables
 - `src/lib/` : utilitaires application
   - `env.ts` : variables d environnement typees
-  - `analyticsInstance.ts` : singleton analytics [v1.0.2]
+  - `analyticsInstance.ts` : singleton analytics [v1.1]
 - `src/shared/` : types et utilitaires transverses
 
-## 5.bis Traceabilite v1.0.2
+## 5.bis Traceabilite v1.1
 
 Specifications locales actives :
 
 - `spec:counter/scoring-access-modes`
 - `spec:counter/offline-scoring-terminal-foundation`
 - `spec:counter/voice-scoring-reliability`
-- `spec:counter/release-v1.0.1-stabilization`
+- `spec:counter/voice-token-provisioning-hardening`
+- `spec:counter/release-governance-v1.0.x`
 - `spec:counter/score-layout-font-scale-resilience`
 - `spec:counter/inp-phase1-quick-wins`
 - `spec:counter/gotcha-game`
 - `spec:counter/killer-game`
+- `spec:counter/arch-single-responsibility-split`
+- `spec:counter/x01-double-out-checkout-rate`
+- `spec:counter/vercel-spa-pageviews-and-flags`
+- `spec:counter/react-19-migration`
+- `spec:counter/release-v1.1-stabilization`
 
 Points d entree canoniques :
 
@@ -159,11 +165,17 @@ Points d entree canoniques :
 - `src/app/useGameLifecycle.ts` [v1.0.2]
 - `src/application/scoring/*`
 - `src/features/game-setup/setupModel.ts`
-- `src/features/game-setup/setupPresentation.ts` [v1.0.2]
-- `src/features/x01/hooks/useMatchTimer.ts` [v1.0.2]
-- `src/features/x01/hooks/useMatchShortcuts.ts` [v1.0.2]
+- `src/features/game-setup/setupPresentation.ts` [v1.1]
+- `src/features/x01/hooks/useMatchTimer.ts` [v1.1]
+- `src/features/x01/hooks/useMatchShortcuts.ts` [v1.1]
+- `src/features/x01/voice/voiceSessionModel.ts` [v1.1]
+- `src/features/x01/voice/voiceProposalModel.ts` [v1.1]
+- `src/domain/triathlon/triathlonScoringRules.ts` [v1.1]
+- `src/features/capital/capitalGameModel.ts` [v1.1]
+- `src/features/cricket/cricketGameModel.ts` [v1.1]
 - `src/infrastructure/local/IndexedDBSessionRepository.ts`
 - `src/features/x01/voice/*`
+- `App.tsx`
 - `views/HomeView.tsx`
 - `views/MatchView.tsx`
 
@@ -175,6 +187,12 @@ Jeux de tests clefs :
 - `tests/unit/application/indexedDbSessionRepository.test.ts`
 - `tests/unit/dartsSpeechParser.test.ts`
 - `tests/unit/x01/matchScoring.test.ts`
+- `tests/unit/x01/voiceSessionModel.test.ts`
+- `tests/unit/x01/voiceProposalModel.test.ts`
+- `tests/unit/gameSetup/setupViewModel.test.ts`
+- `tests/unit/capitalGameModel.test.ts`
+- `tests/unit/cricketGameModel.test.ts`
+- `tests/unit/observability/analyticsApplication.test.ts`
 - `tests/e2e/app.smoke.spec.ts`
 - `tests/e2e/gameplay-entry.smoke.spec.ts`
 
@@ -228,10 +246,10 @@ Principes :
 
 Fichiers cibles du prochain cycle de decoupe :
 
-- `views/SetupView.tsx` : extraire encore `GameRulesSection` si la configuration jeu continue d'evoluer
-- `src/features/x01/voice/useDeepgramStreaming.ts` : extraire les callbacks evenementiels si le flux vocal continue d'evoluer
-- `views/CapitalGameView.tsx` : sortir le rendu winner/stats si de nouvelles variantes arrivent
-- `views/CricketGameView.tsx` : sortir un hook de tour si le flux cricket grandit encore
+- `views/SetupView.tsx` : extractions UI additionnelles uniquement si le flux setup regrossit
+- `src/features/x01/voice/useDeepgramStreaming.ts` : callbacks supplementaires seulement si le protocole voix s'elargit
+- `views/CapitalGameView.tsx` : rendu winner/stats si une nouvelle variante le justifie
+- `views/CricketGameView.tsx` : hook d orchestration de tour si le flux cricket s enrichit encore
 
 ## 9. Environment Model
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -4,8 +4,9 @@ Ce document regroupe les informations techniques qui ne doivent pas alourdir le 
 
 ## Etat du projet
 
-- Version de reference : `v1.0.2`
+- Version de reference : `v1.1.0`
 - Application Vite / React
+- Base frontend alignee sur `React 19`
 - Scorage offline-first
 - Jeux supportes : `X01`, `501 Double Out`, `Cricket`, `Capital`, `Killer`, `Gotcha`, `Triathlon`
 - Assistance vocale `X01` optionnelle
@@ -45,7 +46,6 @@ Format des noms:
 Flags actifs actuellement:
 
 - `game-x01`
-- `game-x01-501-bo5`
 - `game-cricket`
 - `game-capital`
 - `game-gotcha`
@@ -71,7 +71,7 @@ Implementation (clean architecture):
 - Domaine: `src/domain/observability/analyticsDomain.ts` (conventions events/flags + mapping jeu -> flag)
 - Application: `src/application/observability/analyticsUseCases.ts` (use-cases `syncFeatureFlags` et `trackGameEvent`)
 - Infrastructure: `src/infrastructure/observability/vercelAnalyticsAdapter.ts` (adapter Vercel + emission DOM `data-flag-values`)
-- Instance partagee: `src/lib/analyticsInstance.ts` [v1.0.2] (singleton module-level, evite la double instanciation)
+- Instance partagee: `src/lib/analyticsInstance.ts` [v1.1] (singleton module-level, evite la double instanciation)
 
 Variables privees utiles pour l'assistance vocale :
 
@@ -131,6 +131,8 @@ La qualite du projet repose aussi sur :
 - [Scoring access modes](architecture/scoring-access-modes.md)
 - [Fondation offline-first](architecture/scoring-terminal-offline-first-foundation.md)
 - [Audit securite Vercel et performance](audit-security-vercel-performance-2026-04-24.md)
+- [Release v1.1](release/v1.1.md)
+- [Coverage map v1.1](release/v1.1-coverage-map.md)
 - [Release v1.0.2](release/v1.0.2.md)
 - [Release v1.0.1](release/v1.0.1.md)
 - [Coverage map v1.0.1](release/v1.0.1-coverage-map.md)

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -31,7 +31,6 @@ Variables publiques utiles :
 - `VITE_APP_URL`
 - `VITE_APP_ACCESS_MODE`
 - `VITE_ENABLE_VOICE_SCORING`
-- `VITE_TOURNAMENT_API_URL`
 - `VITE_LOG_LEVEL`
 
 ## Analytics Vercel: convention flags/events
@@ -84,7 +83,6 @@ Regles importantes :
 - Les variables `VITE_*` sont publiques cote frontend.
 - Les cles privees ne doivent jamais etre exposees au navigateur.
 - L'assistance vocale reste optionnelle et garde toujours un fallback manuel.
-- `VITE_TOURNAMENT_API_URL` reste optionnelle et ne sert qu'aux integrations futures cote systeme maitre.
 
 ## Scripts utiles
 

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Analytics } from '@vercel/analytics/react';
+import type { BeforeSend } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import './src/styles/tailwind.css';
 import { App } from './App';
@@ -16,6 +17,15 @@ const logRuntimeInfo = (...args: unknown[]) => {
   if (env.VITE_LOG_LEVEL === 'debug') {
     console.info(...args);
   }
+};
+
+const filterRedundantRootPageView: BeforeSend = (event) => {
+  if (event.type !== 'pageview') {
+    return event;
+  }
+
+  const pathname = new URL(event.url).pathname;
+  return pathname === '/' ? null : event;
 };
 
 if (typeof document !== 'undefined') {
@@ -80,7 +90,7 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <App />
-    <Analytics />
+    <Analytics beforeSend={filterRedundantRootPageView} />
     <SpeedInsights />
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bougnat-darts",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bougnat-darts",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@deepgram/sdk": "^5.0.0",
         "@vercel/analytics": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,16 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^0.577.0",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.2",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^22.14.0",
-        "@types/react": "^18.3.28",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
         "@vitejs/plugin-legacy": "^6.1.1",
@@ -3487,32 +3487,24 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
+      "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5443,6 +5435,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5878,18 +5871,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6293,28 +6274,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-refresh": {
@@ -6503,13 +6480,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bougnat-darts",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.1.0",
   "packageManager": "npm@10.9.7",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "lucide-react": "^0.577.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^22.14.0",
-    "@types/react": "^18.3.28",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitejs/plugin-legacy": "^6.1.1",

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -23,7 +23,6 @@ const values = {
   VITE_APP_NAME: readValue('VITE_APP_NAME'),
   VITE_APP_VERSION: readValue('VITE_APP_VERSION'),
   VITE_APP_URL: readValue('VITE_APP_URL'),
-  VITE_TOURNAMENT_API_URL: readValue('VITE_TOURNAMENT_API_URL'),
   VITE_ENABLE_VOICE_SCORING: readValue('VITE_ENABLE_VOICE_SCORING'),
   DEEPGRAM_PROJECT_ID: readValue('DEEPGRAM_PROJECT_ID'),
   DEEPGRAM_API_KEY: readValue('DEEPGRAM_API_KEY'),
@@ -58,10 +57,6 @@ if (!isHttpsUrl(values.VITE_APP_URL)) {
   errors.push(`VITE_APP_URL cannot point to localhost for ${targetLabel}.`);
 }
 
-if (values.VITE_TOURNAMENT_API_URL && !isHttpsUrl(values.VITE_TOURNAMENT_API_URL)) {
-  errors.push('VITE_TOURNAMENT_API_URL must be a valid https URL when provided.');
-}
-
 if (!values.VITE_APP_NAME) {
   warnings.push(`VITE_APP_NAME is empty. The app will still work, but naming will be less explicit in ${targetLabel}.`);
 }
@@ -87,7 +82,6 @@ console.log(`App name           : ${values.VITE_APP_NAME || '(missing)'}`);
 console.log(`App environment    : ${values.VITE_APP_ENV || '(missing)'}`);
 console.log(`App URL            : ${values.VITE_APP_URL || '(missing)'}`);
 console.log(`App version        : ${values.VITE_APP_VERSION || '(missing / optional)'}`);
-console.log(`Tournament API     : ${values.VITE_TOURNAMENT_API_URL || '(optional / not set)'}`);
 console.log(`Voice scoring      : ${values.VITE_ENABLE_VOICE_SCORING || '(missing)'}`);
 console.log(`Deepgram project   : ${values.DEEPGRAM_PROJECT_ID || '(optional / not set)'}`);
 console.log('');

--- a/specs/003-counter-voice-scoring-reliability/plan.md
+++ b/specs/003-counter-voice-scoring-reliability/plan.md
@@ -4,3 +4,6 @@
 2. Encapsuler les flux Deepgram dans un adapter UI
 3. Renforcer la dégradation vers le manuel
 4. Couvrir le flux par des tests unitaires explicites
+5. Introduire une session vocale bornee au tour pour invalider les callbacks stale
+6. Ajouter une couche d arbitrage metier des propositions vocales avant affichage UI
+7. Formaliser les etats de readiness / erreur Deepgram et les mesurer en tests

--- a/specs/003-counter-voice-scoring-reliability/spec.md
+++ b/specs/003-counter-voice-scoring-reliability/spec.md
@@ -11,18 +11,24 @@
 
 Garantir que l assistance vocale `X01` reste une aide de scorage fiable, optionnelle et bornee au vocabulaire darts, sans jamais court-circuiter la validation manuelle du scoreur.
 
+Cette spec couvre aussi la prochaine passe d optimisation Deepgram/voice runtime. Aucun doublon de spec ne doit etre cree pour ce sujet tant que le perimetre reste borne au scoring vocal optionnel `X01`.
+
 ## Decisions
 
 - la transcription vocale propose un score, elle ne l applique jamais seule
 - le fallback manuel reste toujours disponible
 - le parsing s appuie sur des seuils et des garde-fous explicites
 - la connexion Deepgram reste encapsulee dans une couche dédiée
+- les optimisations Deepgram doivent prioriser la fiabilite de tour, la lisibilite des etats runtime et la reduction des re-listens inutiles pour le scoreur
+- la logique metier de proposition vocale doit rester separable du transport Deepgram et des details Web Audio
 
 ## Invariants critiques
 
 - aucun score vocal ne doit être validé sans confirmation explicite
 - le mode vocal ne doit pas casser la saisie manuelle
 - les erreurs réseau ou de transcription doivent dégrader gracieusement vers le manuel
+- aucune utterance stale ne doit survivre a un changement de tour, de joueur, d ecran ou de partie
+- le scoreur doit comprendre pourquoi la voix est indisponible: micro, token, websocket, timeout ou transcription ambiguë
 
 ## Impacted Code
 
@@ -30,7 +36,14 @@ Garantir que l assistance vocale `X01` reste une aide de scorage fiable, optionn
 - `src/features/x01/voice/dartsSpeechParserScoring.ts`
 - `src/features/x01/voice/dartsSpeechParserShared.ts`
 - `src/features/x01/voice/useDeepgramStreaming.ts`
+- `src/features/x01/voice/voiceStreamingModel.ts`
+- `src/features/x01/voice/audioContextManager.ts`
+- `src/features/x01/voice/deepgramConnectionManager.ts`
+- `src/features/x01/voice/deepgramClient.ts`
+- `src/features/x01/voice/VoiceScoringControl.tsx`
 - `src/features/x01/voice/voiceConfig.ts`
+- `views/MatchView.tsx`
+- `api/deepgram/token.ts`
 
 ## Canonical Entry Points
 
@@ -38,14 +51,55 @@ Garantir que l assistance vocale `X01` reste une aide de scorage fiable, optionn
 - `normalizeDartsTranscript`
 - `useDeepgramStreaming`
 - `buildDeepgramListenConfig`
+- `fetchDeepgramAccessToken`
+- `VoiceScoringControl`
 
 ## Key Tests
 
 - `tests/unit/dartsSpeechParser.test.ts`
 - `tests/unit/x01/matchScoring.test.ts`
+- `tests/unit/x01/voicePcm.test.ts`
+- `tests/unit/x01/voiceStreamingModel.test.ts`
+- `tests/unit/lib/deepgramToken.test.ts`
+- `tests/unit/api/deepgramTokenRoute.test.ts`
 
 ## Validation
 
 - parsing des annonces de score
 - robustesse face aux confidences faibles
 - dégradation propre vers la saisie manuelle
+- start / stop / timeout / navigation sans resurrection d une session vocale stale
+- statut UI vocal explicite pour les erreurs runtime principales
+- budget de latence vocal acceptable pour un tour local en conditions reseau normales
+
+## Analyse de l implementation actuelle
+
+Forces confirmees:
+
+- le fallback manuel est deja protege et prioritaire
+- le parsing couvre les intentions metier utiles (`turn_score`, `remaining_score`, `darts_sequence`) avec validations darts explicites
+- le provisioning token est deja durci cote serveur
+- la chaine audio / socket a ete recemment decoupee en managers plus testables
+
+Faiblesses restantes a traiter:
+
+- le runtime voice n a pas encore de notion explicite de session de tour ou d identite de tentative; un demarrage asynchrone peut finir alors que le contexte match a deja bouge
+- la proposition vocale reste basee sur une seule utterance a la fois; il manque un arbitrage metier plus riche entre transcript final, contexte checkout/restant et ambiguite utilisateur
+- la couverture de tests ne protege pas encore assez le flux complet `start -> ecoute -> timeout -> reset -> navigation`
+
+## 3 axes d amelioration proposes
+
+1. Session vocale bornee au tour
+
+- Introduire une notion de `voice attempt` / `turn voice session` cote application pour invalider toute utterance, timeout ou ouverture websocket qui ne correspond plus au tour courant.
+- Benefice metier: eviter qu un score vocal d un joueur ou d un tour precedent pollue le tour en cours, surtout en navigation rapide ou en match partage.
+
+2. Arbitration metier de proposition vocale
+
+- Ajouter une couche d application qui arbitre entre score total, score restant et sequence de flechettes selon le contexte de tour, le checkout visé et le niveau d ambiguite.
+- Benefice metier: moins de confirmations inutiles sur les cas simples et moins de mauvaises propositions sur les cas critiques (`reste 32`, `double 16`, tours partiels).
+
+3. Readiness et observabilite Deepgram orientees scoreur
+
+- Formaliser des etats de readiness et d erreur (micro, token, socket, timeout, ambiguite transcript) et borner la latence de demarrage via prewarm/rotation de token et strategie de retry limitee.
+- Benefice metier: demarrage plus rapide au pupitre et comprehension immediate du mode degrade quand la voix ne peut pas aider.

--- a/specs/003-counter-voice-scoring-reliability/tasks.md
+++ b/specs/003-counter-voice-scoring-reliability/tasks.md
@@ -4,3 +4,8 @@
 - [x] Relier le parsing vocal aux règles darts
 - [x] Isoler l adapter Deepgram
 - [x] Couvrir le parser vocal en tests
+- [x] Ajouter un identifiant de session vocale / tentative borne au tour courant
+- [x] Refuser toute utterance ou callback Deepgram stale apres changement de tour ou navigation
+- [x] Ajouter une couche d arbitrage metier entre `turn_score`, `remaining_score` et `darts_sequence`
+- [x] Exposer un etat UI vocal explicite par cause principale (`micro`, `token`, `socket`, `timeout`, `ambigu`) 
+- [ ] Couvrir `start / stop / timeout / reset / navigation` par des tests unitaires ou integration locale cibles

--- a/specs/022-counter-arch-single-responsibility-split/plan.md
+++ b/specs/022-counter-arch-single-responsibility-split/plan.md
@@ -19,3 +19,33 @@
 - [x] Supprimer le type `X01_501_BO5` de `GameType`
 - [x] Supprimer `isQuickPreset` de `SetupView` et `buildSetupPlayers`
 - [x] Nettoyer analytics domain, tests, helpers e2e
+
+## Phase 5 : SetupView split
+
+- [x] Créer `components/game-setup/SetupPlayersSection.tsx` — gestion joueurs, doublettes, bot et starters d'équipe
+- [x] Créer `components/game-setup/SetupSummarySection.tsx` — rendu du résumé de configuration et action de lancement
+- [x] Créer `src/features/game-setup/setupViewModel.ts` — options de joueurs, résumé et fallback labels
+
+## Phase 6 : Voice runtime split
+
+- [x] Créer `src/features/x01/voice/voiceStreamingModel.ts` — file PCM bornée, assemblage d'utterance, normalisation des erreurs
+- [x] Créer `src/features/x01/voice/voiceStreamingLogger.ts` — logs debug bornés au dev, erreurs structurées
+- [x] Réduire `useDeepgramStreaming.ts` à l'orchestration React + I/O Deepgram
+
+## Phase 7 : Triathlon domain split
+
+- [x] Créer `src/domain/triathlon/triathlonTypes.ts` — types scorecards/evenements hors de `utils/triathlonScoring.ts`
+- [x] Créer `src/domain/triathlon/triathlonScoringRules.ts` — regles et fabriques d'evenements vides
+- [x] Garder `utils/triathlonScoring.ts` comme facade compatible
+
+## Phase 8 : Capital / Cricket game models
+
+- [x] Créer `src/features/capital/capitalGameModel.ts` — reducer, snapshots et helpers de fin de partie
+- [x] Créer `src/features/cricket/cricketGameModel.ts` — competiteurs, snapshots, agrégats et resume de match
+- [x] Réduire `CapitalGameView.tsx` et `CricketGameView.tsx` au wiring écran + handlers React
+
+## Phase 9 : Voice managers
+
+- [x] Créer `src/features/x01/voice/audioContextManager.ts` — capture micro, audio graph, cleanup audio
+- [x] Créer `src/features/x01/voice/deepgramConnectionManager.ts` — ouverture socket, wiring handlers, cleanup connexion
+- [x] Réduire `useDeepgramStreaming.ts` aux refs/état React et callbacks métier

--- a/specs/022-counter-arch-single-responsibility-split/spec.md
+++ b/specs/022-counter-arch-single-responsibility-split/spec.md
@@ -1,18 +1,18 @@
 # Spec 022 — Architecture : Découpage Single Responsibility
 
 **Slug** : `spec:counter/arch-single-responsibility-split`
-**Statut** : `delivered` (v1.0.2)
+**Statut** : `active`
 **Milestone** : M6 — Architecture & Technical Cleanup
 
 ## Contexte
 
-`App.tsx`, `views/MatchView.tsx` et `src/features/game-setup/setupModel.ts` avaient évolué en god objects dépassant 500–900 lignes. Chaque fichier portait plusieurs responsabilités : state management, effets secondaires, présentation, orchestration.
+`App.tsx`, `views/MatchView.tsx`, `views/SetupView.tsx`, `src/features/game-setup/setupModel.ts` et `src/features/x01/voice/useDeepgramStreaming.ts` avaient évolué en fichiers centraux trop volumineux. Chaque fichier portait plusieurs responsabilités : state management, effets secondaires, présentation, orchestration ou diagnostics runtime.
 
 Cette concentration rendait les fichiers difficiles à lire, à tester et à faire évoluer.
 
 ## Objectif
 
-Découper chaque fichier central en modules à responsabilité unique, sans modifier le comportement observable de l'application.
+Découper chaque fichier central en modules à responsabilité unique, sans modifier le comportement observable de l'application ni exposer plus d'informations runtime au client.
 
 ## Périmètre
 
@@ -20,6 +20,11 @@ Découper chaque fichier central en modules à responsabilité unique, sans modi
 - `views/MatchView.tsx` → timer extrait dans `src/features/x01/hooks/useMatchTimer.ts`, shortcuts dans `src/features/x01/hooks/useMatchShortcuts.ts`
 - `src/features/game-setup/setupModel.ts` → fonctions présentation extraites dans `src/features/game-setup/setupPresentation.ts`
 - Analytics singleton extrait dans `src/lib/analyticsInstance.ts`
+- `views/SetupView.tsx` → sections UI extraites dans `components/game-setup/SetupPlayersSection.tsx` et `components/game-setup/SetupSummarySection.tsx`, helpers de composition dans `src/features/game-setup/setupViewModel.ts`
+- `src/features/x01/voice/useDeepgramStreaming.ts` → assemblage d'utterance / buffer PCM extraits dans `src/features/x01/voice/voiceStreamingModel.ts`, diagnostics extraits dans `src/features/x01/voice/voiceStreamingLogger.ts`
+- `utils/triathlonScoring.ts` → types et regles extraits dans `src/domain/triathlon/`
+- `views/CapitalGameView.tsx` → state machine extraite dans `src/features/capital/capitalGameModel.ts`
+- `views/CricketGameView.tsx` → helpers competiteurs / snapshots / resume extraits dans `src/features/cricket/cricketGameModel.ts`
 
 ## Hors périmètre
 
@@ -33,3 +38,34 @@ Découper chaque fichier central en modules à responsabilité unique, sans modi
 - Aucune régression sur les 120 tests unitaires existants
 - CI vert obligatoire après chaque sous-tâche
 - Aucune feature exploratoire introduite
+- Les logs client ne doivent pas exposer des payloads vocaux complets ni des erreurs fournisseur brutes
+
+## Decision v1.0.3
+
+Le refactoring courant prolonge la spec 022 sur les hotspots encore ouverts sans changement fonctionnel volontaire.
+
+- `SetupView.tsx` : extraction de la configuration joueurs/bot et du résumé de match hors du composant écran
+- `setupViewModel.ts` : centralisation des options joueurs, labels de résumé et choix de starters d'équipes
+- `useDeepgramStreaming.ts` : extraction de l'assemblage des utterances, de la file PCM bornée et du logging runtime
+- `voiceStreamingLogger.ts` : logs debug limités au mode dev, erreurs client structurées sans payload brut
+
+Resultat: baisse du couplage dans le setup et le voice streaming, nouveaux helpers purs testés, et réduction du bruit de logs sensibles côté navigateur.
+
+## Decision v1.0.4
+
+La passe courante poursuit le backlog de decoupe sur les fichiers de domaine et les ecrans de match encore trop couplés.
+
+- `utils/triathlonScoring.ts` : types et regles formalisés dans `src/domain/triathlon/triathlonTypes.ts` et `src/domain/triathlon/triathlonScoringRules.ts`
+- `CapitalGameView.tsx` : reducer, snapshots et tri des résultats sortis dans `src/features/capital/capitalGameModel.ts`
+- `CricketGameView.tsx` : competiteurs, snapshots, agrégats et resume de match sortis dans `src/features/cricket/cricketGameModel.ts`
+- `useDeepgramStreaming.ts` : gestion audio et connexion Deepgram sorties dans `audioContextManager.ts` et `deepgramConnectionManager.ts`
+
+Resultat: le domaine triathlon n'est plus embarqué dans un utilitaire unique, les vues Capital/Cricket perdent leur logique pure la plus dense, et le hook voice se recentre sur l'orchestration React.
+
+Fichiers restant a decouvper (backlog):
+
+- `views/SetupView.tsx` : poursuivre l'extraction de `GameRulesSection` si le flux setup evolue encore
+- `src/features/x01/voice/useDeepgramStreaming.ts` : poursuivre le decoupage fin des callbacks evenementiels si le flux vocal evolue encore
+- `views/CapitalGameView.tsx` : extraire le rendu winner/statistiques si de nouvelles variantes UI arrivent
+- `views/CricketGameView.tsx` : extraire un hook d'orchestration de tour si le flux cricket continue de grossir
+- `utils/triathlonScoring.ts` : migrer eventuellement les calculateurs d'epreuves vers `src/domain/triathlon/` si de nouvelles regles sont ajoutees

--- a/specs/022-counter-arch-single-responsibility-split/tasks.md
+++ b/specs/022-counter-arch-single-responsibility-split/tasks.md
@@ -10,12 +10,26 @@
 | useMatchShortcuts.ts extrait de MatchView | `71ff0f0` | ✅ livré |
 | setupPresentation.ts extrait de setupModel | `71ff0f0` | ✅ livré |
 | Suppression X01_501_BO5 / isQuickPreset | `55f6bb0` | ✅ livré |
+| SetupPlayersSection.tsx extrait de SetupView | local | ✅ livré |
+| SetupSummarySection.tsx extrait de SetupView | local | ✅ livré |
+| setupViewModel.ts helpers de composition | local | ✅ livré |
+| voiceStreamingModel.ts helpers purs Deepgram | local | ✅ livré |
+| voiceStreamingLogger.ts logs structures | local | ✅ livré |
+| triathlonTypes.ts et triathlonScoringRules.ts | local | ✅ livré |
+| capitalGameModel.ts state machine | local | ✅ livré |
+| cricketGameModel.ts helpers de match | local | ✅ livré |
+| audioContextManager.ts capture audio | local | ✅ livré |
+| deepgramConnectionManager.ts socket Deepgram | local | ✅ livré |
 
 ## Résultat
 
 - App.tsx : 530 → 347 lignes (−183)
 - MatchView.tsx : 892 → 848 lignes (−44)
 - setupModel.ts : 609 → 459 lignes (−150)
-- 5 nouveaux modules à responsabilité unique
+- SetupView.tsx : sections joueurs + resume extraites vers 2 composants et 1 helper metier de presentation
+- useDeepgramStreaming.ts : helpers buffer/transcript/logging/audio/socket extraits vers 4 modules
+- triathlonScoring.ts : types/regles sortis du fichier utilitaire historique
+- CapitalGameView.tsx / CricketGameView.tsx : logique pure déplacée vers des game models dédiés
+- 15 nouveaux modules à responsabilité unique au total sur la spec
 - 12 fichiers nettoyés (suppression X01_501_BO5)
-- CI vert : 120/120 tests
+- CI local vert : 132/132 tests unitaires + typecheck

--- a/specs/023-counter-x01-double-out-checkout-rate/plan.md
+++ b/specs/023-counter-x01-double-out-checkout-rate/plan.md
@@ -1,0 +1,4 @@
+1. Formaliser la nouvelle definition du checkout rate Double Out
+2. Ecrire des tests unitaires qui couvrent finish, bust et placement volontaire
+3. Adapter `matchStats` pour compter des tentatives reelles a partir de l historique
+4. Verifier la compatibilite du presenter et relancer le typecheck

--- a/specs/023-counter-x01-double-out-checkout-rate/spec.md
+++ b/specs/023-counter-x01-double-out-checkout-rate/spec.md
@@ -1,0 +1,51 @@
+# Spec 023 - counter x01 double out checkout rate
+
+## Meta
+
+- ID: `023-counter-x01-double-out-checkout-rate`
+- Statut: `active`
+- Milestone cible: `M6: Architecture & Technical Cleanup`
+- Issues GitHub: `#to-create`
+
+## Objectif
+
+Redefinir le taux de checkout X01 en `Double Out` pour mesurer des tentatives reelles de finish, sans penaliser les tours de placement joues depuis une plage de checkout.
+
+## Decisions
+
+- le calcul reste dans la couche application, sans dependance React ni UI
+- une opportunite de checkout reste un score de depart de tour finissable en 3 flechettes ou moins
+- une tentative de checkout est comptee uniquement si le tour depuis cette opportunite se termine par un finish reussi ou par un bust
+- un tour de placement depuis une opportunite de checkout ne compte pas comme tentative
+- le detail `1 fleche / 2 fleches / 3 fleches` repose sur les flechettes reellement lancees sur la tentative comptee
+
+## Invariants critiques
+
+- aucune chaine de presentation n est ajoutee dans `matchStats`
+- le taux de checkout reste derive uniquement de l historique de match et des regles X01
+- en `Double Out`, un placement volontaire ne degrade plus le taux de checkout
+- un finish valide continue a compter comme tentative et comme reussite
+- un bust depuis une opportunite de checkout compte comme tentative ratee
+
+## Impacted Code
+
+- `src/application/scoring/matchStats.ts`
+- `tests/unit/application/matchStats.test.ts`
+- `src/presentation/stats/statsPresenter.fr.ts`
+
+## Canonical Entry Points
+
+- `calculateDetailedStats*`
+- `getMinDartsForScore`
+
+## Key Tests
+
+- `tests/unit/application/matchStats.test.ts`
+- `npm run test:unit -- tests/unit/application/matchStats.test.ts`
+- `npm run typecheck`
+
+## Validation
+
+- un checkout reussi en 1, 2 ou 3 flechettes alimente le bon bucket
+- un bust depuis une opportunite de checkout augmente les tentatives sans augmenter les reussites
+- un score de placement depuis une opportunite de checkout ne modifie pas les tentatives

--- a/specs/023-counter-x01-double-out-checkout-rate/tasks.md
+++ b/specs/023-counter-x01-double-out-checkout-rate/tasks.md
@@ -1,0 +1,4 @@
+- [x] Creer la spec locale checkout rate double out
+- [x] Ajouter les tests unitaires `matchStats` pour placement, bust et finish
+- [x] Refactorer le calcul des tentatives checkout dans `matchStats`
+- [x] Valider avec tests cibles et `npm run typecheck`

--- a/specs/024-counter-vercel-spa-pageviews-and-flags/plan.md
+++ b/specs/024-counter-vercel-spa-pageviews-and-flags/plan.md
@@ -1,0 +1,7 @@
+# Plan - Spec 024
+
+1. Etendre le port analytics pour supporter les `pageview` manuels.
+2. Introduire un mapping centralise entre `AppScreen` et route analytique.
+3. Instrumenter `App.tsx` pour emettre un `pageview` a chaque changement d ecran hydrate.
+4. Conserver et verifier la synchronisation des flags avant emission du `pageview`.
+5. Ajouter des tests unitaires d orchestration application.

--- a/specs/024-counter-vercel-spa-pageviews-and-flags/spec.md
+++ b/specs/024-counter-vercel-spa-pageviews-and-flags/spec.md
@@ -1,0 +1,54 @@
+# Spec 024 - counter vercel spa pageviews and flags
+
+## Meta
+
+- ID: `024-counter-vercel-spa-pageviews-and-flags`
+- Statut: `active`
+- Milestone cible: `M6: Architecture & Technical Cleanup`
+- Issues GitHub: `#to-create`
+
+## Objectif
+
+Rendre les ecrans logiques de l application visibles dans Vercel Web Analytics `Pages` et faire remonter des `Flags` coherents pour la navigation SPA du compteur de darts.
+
+## Decisions
+
+- l integration conserve `@vercel/analytics/react` au bootstrap pour rester compatible avec le build Vite deploie par Vercel depuis GitHub
+- les changements d ecran internes de la SPA emettent des `pageview` manuels avec une route stable et lisible par ecran
+- les flags applicatifs restent construits dans la couche domaine et synchronises via le port analytics
+- les `pageview` manuels sont emis apres synchronisation des flags pour permettre l attribution des donnees de page aux flags actifs
+- les evenements custom conservent la clean architecture existante sans couplage direct a React
+
+## Invariants critiques
+
+- aucune logique Vercel ne remonte dans la couche presentation hors orchestration `App.tsx`
+- le mapping ecran -> route est deterministe et ne depend pas du navigateur
+- la solution reste valide quand le build est declenche par GitHub puis deploye sur Vercel
+- les `Pages` Vercel distinguent les grands ecrans applicatifs meme si l URL du navigateur ne change pas
+
+## Impacted Code
+
+- `App.tsx`
+- `src/application/observability/analyticsPort.ts`
+- `src/application/observability/analyticsUseCases.ts`
+- `src/domain/observability/analyticsDomain.ts`
+- `src/infrastructure/observability/vercelAnalyticsAdapter.ts`
+- `tests/unit/observability/analyticsApplication.test.ts`
+
+## Canonical Entry Points
+
+- `trackPageView`
+- `buildAnalyticsPageView`
+- `createVercelAnalyticsPort`
+
+## Key Tests
+
+- `tests/unit/observability/analyticsApplication.test.ts`
+- `npm run test:unit -- tests/unit/observability/analyticsApplication.test.ts`
+- `npm run typecheck`
+
+## Validation
+
+- un changement d ecran SPA emet un `pageview` manuel avec un `route` et un `path` metiers stables
+- la synchronisation de flags precede l emission du `pageview` manuel
+- les evenements custom existants continuent a etre delegues sans regression

--- a/specs/024-counter-vercel-spa-pageviews-and-flags/tasks.md
+++ b/specs/024-counter-vercel-spa-pageviews-and-flags/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - Spec 024
+
+- [x] ajouter le support `trackPageView` au port analytics
+- [x] definir un mapping stable `screen -> route/path`
+- [x] emettre des `pageview` sur navigation SPA hydratee
+- [x] couvrir le flow par tests unitaires
+- [x] valider par tests cibles et typecheck

--- a/specs/025-counter-react-19-migration/checklist.md
+++ b/specs/025-counter-react-19-migration/checklist.md
@@ -1,0 +1,62 @@
+# Checklist operationnelle executable - Spec 025
+
+## Phase 1 - Preparation React 18.3
+
+1. Mettre a jour les dependances:
+   - `npm install react@18.3 react-dom@18.3`
+2. Executer les controles techniques:
+   - `npm run typecheck`
+   - `npm run lint`
+   - `npm run test:unit`
+   - `npm run build`
+3. Relever et corriger les warnings React 18.3 avant toute suite
+4. Rejouer localement les flux sensibles:
+   - scoring vocal start/stop
+   - navigation pendant ecoute
+   - timers de partie
+   - restauration de session
+   - update service worker
+
+## Phase 2 - Migration React 19
+
+1. Mettre a jour les dependances:
+   - `npm install react@19 react-dom@19 @types/react@19 @types/react-dom@19`
+2. Executer le codemod types:
+   - `npx types-react-codemod@latest preset-19 .`
+3. Corriger le code casse par la migration
+4. Executer la batterie complete:
+   - `npm run ci:check`
+   - `npm run test:e2e`
+5. Verifier manuellement:
+   - `App.tsx` sous `Suspense`
+   - points d entree `createRoot`
+   - analytics/speed insights
+   - PWA et service worker
+
+## Phase 3 - Validation produit
+
+1. Tester les jeux:
+   - X01 complet
+   - Cricket
+   - Capital
+   - Killer
+   - Gotcha
+   - Triathlon
+2. Tester les parcours transverses:
+   - undo/rematch
+   - installation app
+   - live update
+   - retour depuis un match en cours
+3. Tester les plateformes cibles:
+   - mobile
+   - tablette paysage
+   - Safari/iOS legacy ou BrowserStack equivalent
+4. Valider en preview Vercel avant merge/release
+
+## Definition of done
+
+- `npm run ci:check` vert
+- `npm run test:e2e` vert ou ecarts documentes et acceptes
+- aucun warning React bloquant restant
+- parcours metier critiques verifies
+- validation preview Vercel effectuee

--- a/specs/025-counter-react-19-migration/commits.md
+++ b/specs/025-counter-react-19-migration/commits.md
@@ -1,0 +1,40 @@
+# Serie de commits proposee - Spec 025
+
+## Phase 1 - Preparation React 18.3
+
+1. `chore(frontend): upgrade react runtime to 18.3`
+   - bump `react` et `react-dom` vers `18.3.x`
+   - conserver les types actuels si aucun warning type ne l exige encore
+
+2. `fix(runtime): stabilize strict mode side effects before react 19`
+   - corriger les hooks a cleanup fragile
+   - fiabiliser audio, micro, websocket, timers ou service worker si necessaire
+
+3. `test(frontend): lock react 18.3 migration baseline`
+   - ajuster ou completer les tests couvrant les regressions detectees
+
+## Phase 2 - Migration React 19
+
+1. `chore(frontend): upgrade to react 19 and types`
+   - bump `react`, `react-dom`, `@types/react`, `@types/react-dom`
+
+2. `refactor(types): apply react 19 codemods and jsx fixes`
+   - appliquer `types-react-codemod`
+   - corriger refs, JSX et signatures de composants
+
+3. `fix(frontend): adapt lazy suspense and integration surfaces for react 19`
+   - corriger les regressions constatees sur `Suspense`, analytics, PWA ou bootstrap si necessaire
+
+## Phase 3 - Validation produit
+
+1. `test(e2e): cover critical game flows on react 19`
+   - renforcer les scenarios Playwright sur les parcours critiques si la couverture manque
+
+2. `docs(release): document react 19 validation matrix and rollout decision`
+   - consigner les verifications manuelles, legacy et preview Vercel
+
+## Regle de packaging
+
+- ne pas melanger bump de dependances et fixes runtime complexes dans un meme commit si un diff plus petit reste reviewable
+- preferer un commit par cause technique observable
+- garder la validation finale produit dans un commit ou document separe des changements framework

--- a/specs/025-counter-react-19-migration/plan.md
+++ b/specs/025-counter-react-19-migration/plan.md
@@ -1,0 +1,24 @@
+# Plan - Spec 025
+
+## Phase 1 - Preparation React 18.3
+
+1. Mettre a jour `react` et `react-dom` vers `18.3.x`
+2. Rejouer `typecheck`, `lint`, `test:unit` et `build`
+3. Corriger les warnings de transition remontes par React 18.3
+4. Auditer et stabiliser les hooks/effets sensibles: audio, micro, websocket, timers, service worker, restauration
+
+## Phase 2 - Migration framework React 19
+
+1. Mettre a jour `react`, `react-dom`, `@types/react` et `@types/react-dom` vers la cible React 19
+2. Lancer `npx types-react-codemod@latest preset-19 .`
+3. Corriger les impacts de typage JSX, refs et signatures de composants
+4. Rejouer la verification technique complete `ci:check`
+5. Verifier les integrations frontend critiques: Suspense/lazy, analytics, speed insights, PWA
+
+## Phase 3 - Validation produit et runtime
+
+1. Rejouer les parcours metier majeurs par mode de jeu
+2. Tester le scoring vocal et les transitions d ecran pendant ecoute
+3. Verifier PWA, update lifecycle, session restore et navigation tactile/tablette
+4. Rejouer les validations legacy iOS/Safari ou equivalent BrowserStack
+5. Ouvrir la promotion release seulement apres validation preview Vercel

--- a/specs/025-counter-react-19-migration/spec.md
+++ b/specs/025-counter-react-19-migration/spec.md
@@ -1,0 +1,63 @@
+# Spec 025 - counter react 19 migration
+
+## Meta
+
+- ID: `025-counter-react-19-migration`
+- Statut: `active`
+- Milestone cible: `M6: Architecture & Technical Cleanup`
+- Issues GitHub: `#to-create`
+
+## Objectif
+
+Faire migrer `Bougnat_darts_counter` de React 18.2 vers une cible React 19 de maniere progressive, spec-driven et compatible avec la clean architecture existante.
+
+## Decisions
+
+- la migration se fait en 3 phases distinctes: preparation en React 18.3, migration framework vers React 19, validation produit/runtime
+- la phase 1 sert a absorber les warnings de transition React sans ouvrir un chantier fonctionnel annexe
+- les adaptations de code restent limitees aux frontieres framework, types JSX et effets runtime sensibles
+- les couches domain, application et infrastructure ne doivent pas etre refactorees sans besoin directement prouve par la migration React
+- toute correction d effet non idempotent doit rester locale au composant, hook ou adapter qui controle reellement le lifecycle concerne
+- la migration doit etre compatible avec le build GitHub puis le deploiement Vercel deja en place
+
+## Invariants critiques
+
+- aucune regression fonctionnelle sur les parcours de jeux X01, Cricket, Capital, Killer, Gotcha et Triathlon
+- aucune regression sur le scoring vocal, les websockets Deepgram, les timers, le PWA/service worker et la restauration de session
+- aucune dependance React ne doit contourner les ports et adapters existants juste pour satisfaire la migration
+- les tests existants restent verts avant et apres chaque phase
+- la compatibilite legacy iOS/Safari reste un critere explicite de validation finale
+
+## Impacted Code
+
+- `package.json`
+- `tsconfig.json`
+- `index.tsx`
+- `App.tsx`
+- `src/app/**`
+- `src/infrastructure/audio/**`
+- `src/infrastructure/voice/**`
+- `src/lib/**`
+- `tests/**`
+
+## Canonical Entry Points
+
+- `index.tsx`
+- `App.tsx`
+- `src/hooks/useDeepgramStreaming.ts`
+- `npm run ci:check`
+
+## Key Tests
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:unit`
+- `npm run build`
+- `npm run test:e2e`
+
+## Validation
+
+- React 18.3 ne remonte plus de warning de transition bloquant
+- React 19 compile avec `@types/react@19` et `@types/react-dom@19`
+- les hooks sensibles au lifecycle restent idempotents en dev sous `StrictMode`
+- les parcours critiques sont verifies manuellement avant merge

--- a/specs/025-counter-react-19-migration/tasks.md
+++ b/specs/025-counter-react-19-migration/tasks.md
@@ -1,0 +1,28 @@
+# Tasks - Spec 025
+
+## Phase 1 - Preparation React 18.3
+
+- [x] mettre a jour `react` et `react-dom` en `18.3.x`
+- [x] executer `npm run typecheck`
+- [x] executer `npm run lint`
+- [x] executer `npm run test:unit`
+- [x] executer `npm run build`
+- [x] verifier qu aucun warning de transition React 18.3 n apparait dans la validation technique automatisee
+- [ ] stabiliser les effets sensibles (audio, micro, websocket, timers, service worker)
+
+## Phase 2 - Migration React 19
+
+- [x] mettre a jour `react`, `react-dom`, `@types/react` et `@types/react-dom`
+- [x] lancer `npx types-react-codemod@latest preset-19 .`
+- [x] verifier qu aucune incompatibilite TypeScript ou JSX bloquante n est remontee
+- [x] executer `npm run ci:check`
+- [ ] valider les surfaces `Suspense`, `lazy`, analytics, speed insights et PWA
+
+## Phase 3 - Validation produit
+
+- [x] tester les parcours smoke X01, Cricket, Capital, Gotcha, Killer et Triathlon via Playwright
+- [ ] tester undo, rematch et retour setup si applicables
+- [ ] tester le scoring vocal Deepgram (start, stop, navigation, timeout)
+- [ ] tester installation PWA et cycle de mise a jour
+- [ ] tester Safari/iOS legacy ou equivalent
+- [ ] valider preview Vercel avant promotion

--- a/specs/026-counter-release-v1-1-stabilization/plan.md
+++ b/specs/026-counter-release-v1-1-stabilization/plan.md
@@ -1,0 +1,24 @@
+# Plan - Spec 026
+
+## Phase 1 - Realigner la base develop
+
+1. Integrer sur `develop` tous les commits valides de `release/1.0.2`
+2. Supprimer les faux contrats d integration hors scope open source
+3. Verifier qu aucun couplage runtime obligatoire au systeme tournoi ne subsiste
+
+## Phase 2 - Aligner version, docs et traçabilite
+
+1. Passer la version package en `1.1.0`
+2. Mettre a jour README, architecture, scope produit, guide technique et contributing
+3. Publier `docs/release/v1.1.md` et `docs/release/v1.1-coverage-map.md`
+4. Actualiser l accueil public et le changelog utilisateur sur `v1.1`
+5. Realigner milestone et issue de pilotage release
+
+## Phase 3 - Gouverner la release
+
+1. Executer `npm run ci:check` sur `develop`
+2. Creer et pousser `release/1.1`
+3. Rejouer les validations release sur `release/1.1`
+4. Poser le tag `v1.1`
+5. Ouvrir la PR `release/1.1 -> main`
+6. Realigner `develop` apres la stabilisation release

--- a/specs/026-counter-release-v1-1-stabilization/spec.md
+++ b/specs/026-counter-release-v1-1-stabilization/spec.md
@@ -1,0 +1,65 @@
+# Spec 026 - counter release v1.1 stabilization
+
+## Meta
+
+- ID: `026-counter-release-v1-1-stabilization`
+- Statut: `active`
+- Milestone cible: `M9: Open Source Release v1.1`
+- Issues GitHub: `#103`
+
+## Objectif
+
+Stabiliser et publier la release `v1.1` de `Bougnat_darts_counter` comme base open source propre, testee, documentee et publiable via `release/1.1` puis PR vers `main`.
+
+## Decisions
+
+- la release `v1.1` consolide les travaux deja valides sur `release/1.0.2`, puis les realigne sur `develop`
+- aucun elargissement du scope open source n est autorise pendant cette stabilisation
+- les clarifications de perimetre doivent supprimer les faux contrats d integration, pas les documenter comme si le runtime en dependait
+- la documentation produit, la couverture spec-driven, le versioning package, l ecran d accueil et la gouvernance Git doivent raconter la meme release
+- la gouvernance de branche, tag et PR reste celle de `spec:counter/release-governance-v1.0.x`
+
+## Invariants critiques
+
+- zero dependance runtime obligatoire a `Bougnat_Darts_Tournaments`
+- zero regression sur le gameplay local, les jeux supportes, la reprise locale et l offline-first
+- le voice scoring reste optionnel avec fallback manuel obligatoire
+- aucun merge direct sur `main`
+- traceabilite commit -> spec -> code -> tests -> issue obligatoire jusqu a la PR release
+
+## Impacted Code
+
+- `package.json`
+- `package-lock.json`
+- `README.md`
+- `docs/architecture.md`
+- `docs/product-scope.md`
+- `docs/technical.md`
+- `docs/specifications.md`
+- `docs/release/v1.1.md`
+- `docs/release/v1.1-coverage-map.md`
+- `views/HomeView.tsx`
+- `components/ui/ChangelogModal.tsx`
+- `specs/README.md`
+
+## Canonical Entry Points
+
+- `package.json`
+- `docs/release/v1.1.md`
+- `docs/release/v1.1-coverage-map.md`
+- `views/HomeView.tsx`
+- `release/1.1`
+
+## Key Tests
+
+- `npm run ci:check`
+- `npm run test:e2e`
+- `npm run preprod:check`
+- `npm run production:check`
+
+## Validation
+
+- `develop` pousse avec la documentation `v1.1` et la version `1.1.0`
+- branche `release/1.1` creee depuis `develop`
+- tag `v1.1` pose sur le commit release valide
+- PR `release/1.1 -> main` ouverte sans merge automatique

--- a/specs/026-counter-release-v1-1-stabilization/tasks.md
+++ b/specs/026-counter-release-v1-1-stabilization/tasks.md
@@ -1,0 +1,30 @@
+# Tasks - Spec 026
+
+## Phase 1 - Base develop
+
+- [x] synchroniser `develop` avec `origin/develop`
+- [x] cherry-pick les commits valides de `release/1.0.2` manquants sur `develop`
+- [x] supprimer le contrat `VITE_TOURNAMENT_API_URL`
+
+## Phase 2 - Version et documentation
+
+- [x] creer le milestone GitHub `M9: Open Source Release v1.1`
+- [x] creer l issue GitHub `#103` de pilotage release `v1.1`
+- [x] ajouter la spec locale `026-counter-release-v1-1-stabilization`
+- [x] aligner `package.json` et `package-lock.json` sur `1.1.0`
+- [x] mettre a jour README, architecture, scope, technical, specifications et contributing
+- [x] creer `docs/release/v1.1.md`
+- [x] creer `docs/release/v1.1-coverage-map.md`
+- [x] actualiser `HomeView` et `ChangelogModal` sur `v1.1`
+
+## Phase 3 - Validation et publication
+
+- [x] executer `npm run ci:check` sur `develop`
+- [ ] creer et pousser `release/1.1`
+- [ ] executer `npm run ci:check` sur `release/1.1`
+- [ ] executer `npm run test:e2e` sur `release/1.1`
+- [ ] executer `npm run preprod:check` sur `release/1.1`
+- [ ] executer `npm run production:check` sur `release/1.1`
+- [ ] creer le tag `v1.1`
+- [ ] ouvrir la PR `release/1.1 -> main`
+- [ ] realigner `develop` apres stabilisation release

--- a/specs/README.md
+++ b/specs/README.md
@@ -116,6 +116,19 @@
   - slug: `spec:counter/react-19-migration`
   - statut: `active`
   - milestone: `M6: Architecture & Technical Cleanup`
+- `026-counter-release-v1-1-stabilization`
+  - slug: `spec:counter/release-v1.1-stabilization`
+  - statut: `active`
+  - milestone: `M9: Open Source Release v1.1`
+
+## Release active
+
+- `spec:counter/release-v1.1-stabilization`
+  - release cible: `v1.1`
+  - issue de pilotage: `#103`
+  - gouvernance associee: `spec:counter/release-governance-v1.0.x`
+
+Les specs `004-counter-release-v1-0-1-stabilization` et `007-counter-release-governance-v1-0-x` restent historiques et servent de base de gouvernance pour `v1.1`.
 
 ## Structure minimale d'une spec
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -103,7 +103,7 @@
   - slug: `spec:counter/arch-single-responsibility-split`
   - statut: `active`
   - milestone: `M6: Architecture & Technical Cleanup`
-  - note: refactoring v1.0.2 — decoupe des god objects (setupModel, App, MatchView)
+  - note: refactoring v1.0.4 — decoupe continue des god objects (SetupView, useDeepgramStreaming, triathlonScoring, CapitalGameView, CricketGameView) apres App, MatchView et setupModel
 - `023-counter-x01-double-out-checkout-rate`
   - slug: `spec:counter/x01-double-out-checkout-rate`
   - statut: `active`

--- a/specs/README.md
+++ b/specs/README.md
@@ -112,6 +112,10 @@
   - slug: `spec:counter/vercel-spa-pageviews-and-flags`
   - statut: `active`
   - milestone: `M6: Architecture & Technical Cleanup`
+- `025-counter-react-19-migration`
+  - slug: `spec:counter/react-19-migration`
+  - statut: `active`
+  - milestone: `M6: Architecture & Technical Cleanup`
 
 ## Structure minimale d'une spec
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -104,6 +104,10 @@
   - statut: `active`
   - milestone: `M6: Architecture & Technical Cleanup`
   - note: refactoring v1.0.2 — decoupe des god objects (setupModel, App, MatchView)
+- `023-counter-x01-double-out-checkout-rate`
+  - slug: `spec:counter/x01-double-out-checkout-rate`
+  - statut: `active`
+  - milestone: `M6: Architecture & Technical Cleanup`
 
 ## Structure minimale d'une spec
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -108,6 +108,10 @@
   - slug: `spec:counter/x01-double-out-checkout-rate`
   - statut: `active`
   - milestone: `M6: Architecture & Technical Cleanup`
+- `024-counter-vercel-spa-pageviews-and-flags`
+  - slug: `spec:counter/vercel-spa-pageviews-and-flags`
+  - statut: `active`
+  - milestone: `M6: Architecture & Technical Cleanup`
 
 ## Structure minimale d'une spec
 

--- a/src/application/observability/analyticsPort.ts
+++ b/src/application/observability/analyticsPort.ts
@@ -1,6 +1,11 @@
-import { AnalyticsPayload, FeatureFlags } from '../../domain/observability/analyticsDomain';
+import {
+  AnalyticsPageView,
+  AnalyticsPayload,
+  FeatureFlags,
+} from '../../domain/observability/analyticsDomain';
 
 export interface AnalyticsPort {
   setFeatureFlagsInDOM: (flags: FeatureFlags) => void;
   trackEvent: (eventName: string, payload: AnalyticsPayload, options?: { flags?: string[] }) => void;
+  trackPageView: (pageView: AnalyticsPageView) => void;
 }

--- a/src/application/observability/analyticsUseCases.ts
+++ b/src/application/observability/analyticsUseCases.ts
@@ -1,5 +1,6 @@
 import { GameType } from '../../../utils/arenaFlow';
 import {
+  AnalyticsPageView,
   AnalyticsPayload,
   FeatureFlags,
 } from '../../domain/observability/analyticsDomain';
@@ -24,4 +25,11 @@ export const trackAnalyticsEvent = (
   payload: AnalyticsPayload,
 ) => {
   analytics.trackEvent(eventName, payload);
+};
+
+export const trackPageView = (
+  analytics: AnalyticsPort,
+  pageView: AnalyticsPageView,
+) => {
+  analytics.trackPageView(pageView);
 };

--- a/src/application/scoring/matchStats.ts
+++ b/src/application/scoring/matchStats.ts
@@ -79,6 +79,12 @@ const isCheckoutOpportunity = (score: number, checkOutRule: InOutRule) => {
   return false;
 };
 
+const getCheckoutAttemptBucket = (dartsThrown: number): 1 | 2 | 3 => {
+  if (dartsThrown <= 1) return 1;
+  if (dartsThrown === 2) return 2;
+  return 3;
+};
+
 const calculateDetailedStatsForParticipant = (
   match: MatchState,
   participantTeamId: string,
@@ -135,12 +141,15 @@ const calculateDetailedStatsForParticipant = (
           nonOutshotDarts += turn.dartsThrown;
         }
 
-        const minDarts = getMinDartsForScore(remainingBeforeTurn, match.config.checkOut);
-        if (isCheckoutOpportunity(remainingBeforeTurn, match.config.checkOut) && minDarts >= 1 && minDarts <= 3) {
-          checkoutBuckets[minDarts].attempts += 1;
-          const isWinningTurn = leg.winnerId === participantTeamId && turnIndex === leg.history.length - 1 && !turn.isBust;
+        const isWinningTurn = leg.winnerId === participantTeamId && turnIndex === leg.history.length - 1 && !turn.isBust;
+        const isRealCheckoutAttempt = isCheckoutOpportunity(remainingBeforeTurn, match.config.checkOut)
+          && (turn.isBust || isWinningTurn);
+
+        if (isRealCheckoutAttempt) {
+          const attemptBucket = getCheckoutAttemptBucket(turn.dartsThrown);
+          checkoutBuckets[attemptBucket].attempts += 1;
           if (isWinningTurn) {
-            checkoutBuckets[minDarts].made += 1;
+            checkoutBuckets[attemptBucket].made += 1;
           }
         }
       }

--- a/src/domain/observability/analyticsDomain.ts
+++ b/src/domain/observability/analyticsDomain.ts
@@ -4,6 +4,11 @@ export type AnalyticsPayloadValue = string | number | boolean | null | undefined
 export type AnalyticsPayload = Record<string, AnalyticsPayloadValue>;
 export type FeatureFlags = Record<string, boolean | string>;
 
+export interface AnalyticsPageView {
+  route: string;
+  path: string;
+}
+
 export const ANALYTICS_EVENT = {
   ScreenView: 'screen_view',
   GameSelected: 'game_selected',
@@ -58,3 +63,71 @@ export const buildGameFeatureFlags = (input: BuildFeatureFlagsInput): FeatureFla
   'voice-scoring-enabled': input.voiceScoringEnabled,
   'app-access-mode': input.appAccessMode,
 });
+
+const gamePathSegment = (gameType: GameType): string => {
+  switch (gameType) {
+    case 'CRICKET':
+      return 'cricket';
+    case 'CAPITAL':
+      return 'capital';
+    case 'GOTCHA':
+      return 'gotcha';
+    case 'KILLER':
+      return 'killer';
+    case 'TRIATHLON':
+      return 'triathlon';
+    case 'X01':
+    default:
+      return 'x01';
+  }
+};
+
+const pageViewForGamePhase = (
+  gameType: GameType,
+  phase: 'setup' | 'match' | 'stats',
+): AnalyticsPageView => {
+  const path = `/app/${gamePathSegment(gameType)}/${phase}`;
+  return { route: path, path };
+};
+
+export const buildAnalyticsPageView = (
+  screen: string,
+  selectedGameType: GameType,
+): AnalyticsPageView => {
+  switch (screen) {
+    case 'HOME':
+      return { route: '/app/home', path: '/app/home' };
+    case 'GAME_SELECTION':
+      return { route: '/app/games', path: '/app/games' };
+    case 'SETUP':
+      return pageViewForGamePhase(selectedGameType, 'setup');
+    case 'MATCH':
+      return pageViewForGamePhase('X01', 'match');
+    case 'STATS':
+      return pageViewForGamePhase('X01', 'stats');
+    case 'CRICKET_GAME':
+      return pageViewForGamePhase('CRICKET', 'match');
+    case 'CRICKET_STATS':
+      return pageViewForGamePhase('CRICKET', 'stats');
+    case 'CAPITAL_GAME':
+      return pageViewForGamePhase('CAPITAL', 'match');
+    case 'CAPITAL_STATS':
+      return pageViewForGamePhase('CAPITAL', 'stats');
+    case 'KILLER_GAME':
+      return pageViewForGamePhase('KILLER', 'match');
+    case 'KILLER_STATS':
+      return pageViewForGamePhase('KILLER', 'stats');
+    case 'GOTCHA_GAME':
+      return pageViewForGamePhase('GOTCHA', 'match');
+    case 'GOTCHA_STATS':
+      return pageViewForGamePhase('GOTCHA', 'stats');
+    case 'TRIATHLON_GAME':
+      return pageViewForGamePhase('TRIATHLON', 'match');
+    case 'TRIATHLON_STATS':
+      return pageViewForGamePhase('TRIATHLON', 'stats');
+    default: {
+      const path = `/app/${screen.toLowerCase()}`;
+      return { route: path, path };
+    }
+  }
+};

--- a/src/domain/triathlon/index.ts
+++ b/src/domain/triathlon/index.ts
@@ -1,0 +1,2 @@
+export * from './triathlonTypes';
+export * from './triathlonScoringRules';

--- a/src/domain/triathlon/triathlonScoringRules.ts
+++ b/src/domain/triathlon/triathlonScoringRules.ts
@@ -1,0 +1,113 @@
+import type { TriathlonBonusLine, TriathlonEventKey, TriathlonEventScore, TriathlonScorecard } from './triathlonTypes';
+
+type RankRule = {
+  rankPoints: number[];
+};
+
+type BonusRule = {
+  points: number;
+  label: string;
+  detail: (value: number) => string;
+};
+
+export const TRIATHLON_SCORING_RULES = {
+  x01: {
+    winnerBasePoints: 20,
+    closeLossBasePoints: 14,
+    standardLossBasePoints: 10,
+    closeLossThresholds: {
+      dartsGap: 3,
+      averageGap: 6,
+    },
+    bonuses: {
+      highestCheckout: {
+        points: 4,
+        label: 'Checkout eleve',
+        detail: (value: number) => `${value}`,
+      } satisfies BonusRule,
+      bestAverage: {
+        points: 5,
+        label: 'Meilleure moyenne',
+        detail: (value: number) => value.toFixed(1),
+      } satisfies BonusRule,
+      fewestDarts: {
+        points: 5,
+        label: 'Moins de flechettes',
+        detail: (value: number) => `${value}`,
+      } satisfies BonusRule,
+    },
+  },
+  cricket: {
+    rank: {
+      rankPoints: [20, 14, 10, 6],
+    } satisfies RankRule,
+    bonuses: {
+      bestMpr: {
+        points: 5,
+        label: 'Meilleur MPR',
+        detail: (value: number) => value.toFixed(2),
+      } satisfies BonusRule,
+      bestScore: {
+        points: 4,
+        label: 'Difference de score',
+        detail: (value: number) => `${value} pts`,
+      } satisfies BonusRule,
+      mostClosedNumbers: {
+        points: 4,
+        label: 'Numeros fermes',
+        detail: (value: number) => `${value}`,
+      } satisfies BonusRule,
+    },
+  },
+  capital: {
+    rank: {
+      rankPoints: [20, 16, 12, 8],
+    } satisfies RankRule,
+    bonuses: {
+      bestScore: {
+        points: 5,
+        label: 'Score cumule',
+        detail: (value: number) => `${value} pts`,
+      } satisfies BonusRule,
+      regularity: {
+        points: 4,
+        label: 'Regularite',
+        detail: (value: number) => `${value} reussites`,
+      } satisfies BonusRule,
+      fewestPenalties: {
+        points: 4,
+        label: 'Peu de penalites',
+        detail: (value: number) => `${value}`,
+      } satisfies BonusRule,
+    },
+  },
+} as const;
+
+export const TRIATHLON_EVENT_LABELS: Record<TriathlonEventKey, string> = {
+  capital: 'Capital',
+  cricket: 'Cricket',
+  x01: '501',
+};
+
+export const createEmptyTriathlonEvent = (key: TriathlonEventKey, label: string): TriathlonEventScore => ({
+  key,
+  label,
+  basePoints: 0,
+  bonusPoints: 0,
+  totalPoints: 0,
+  summary: 'Epreuve non jouee.',
+  bonuses: [],
+});
+
+export const createTriathlonScorecard = (competitorId: string, competitorName: string): TriathlonScorecard => ({
+  competitorId,
+  competitorName,
+  capital: createEmptyTriathlonEvent('capital', TRIATHLON_EVENT_LABELS.capital),
+  cricket: createEmptyTriathlonEvent('cricket', TRIATHLON_EVENT_LABELS.cricket),
+  x01: createEmptyTriathlonEvent('x01', TRIATHLON_EVENT_LABELS.x01),
+  totalBasePoints: 0,
+  totalBonusPoints: 0,
+  totalScore: 0,
+});
+
+export type { TriathlonBonusLine, TriathlonEventKey, TriathlonEventScore, TriathlonScorecard };

--- a/src/domain/triathlon/triathlonTypes.ts
+++ b/src/domain/triathlon/triathlonTypes.ts
@@ -1,0 +1,28 @@
+export type TriathlonEventKey = 'capital' | 'cricket' | 'x01';
+
+export interface TriathlonBonusLine {
+  label: string;
+  points: number;
+  detail: string;
+}
+
+export interface TriathlonEventScore {
+  key: TriathlonEventKey;
+  label: string;
+  basePoints: number;
+  bonusPoints: number;
+  totalPoints: number;
+  summary: string;
+  bonuses: TriathlonBonusLine[];
+}
+
+export interface TriathlonScorecard {
+  competitorId: string;
+  competitorName: string;
+  capital: TriathlonEventScore;
+  cricket: TriathlonEventScore;
+  x01: TriathlonEventScore;
+  totalBasePoints: number;
+  totalBonusPoints: number;
+  totalScore: number;
+}

--- a/src/domain/x01Bot/x01Bot.ts
+++ b/src/domain/x01Bot/x01Bot.ts
@@ -5,6 +5,7 @@ export type X01BotLevelDefinition = {
   label: string;
   averageMin: number;
   averageMax: number;
+  averageDisplayFloor?: number;
 };
 
 export const X01_BOT_LEVELS: X01BotLevelDefinition[] = [
@@ -12,8 +13,44 @@ export const X01_BOT_LEVELS: X01BotLevelDefinition[] = [
   { level: 'LOISIR', label: 'Loisir', averageMin: 40, averageMax: 55 },
   { level: 'CLUB', label: 'Club', averageMin: 55, averageMax: 70 },
   { level: 'CONFIRME', label: 'Confirme', averageMin: 70, averageMax: 85 },
-  { level: 'PRO', label: 'Pro', averageMin: 100, averageMax: 120 },
+  { level: 'PRO', label: 'Pro', averageMin: 86, averageMax: 120, averageDisplayFloor: 85 },
 ];
+
+const X01_BOT_FIRST_NAMES = [
+  'Alexis',
+  'Alice',
+  'Arthur',
+  'Bruno',
+  'Cyril',
+  'Chloe',
+  'Clara',
+  'Clement',
+  'Emma',
+  'Enzo',
+  'Florian',
+  'Gabriel',
+  'Guillaume',
+  'Hugo',
+  'Jade',
+  'Julien',
+  'Lea',
+  'Leo',
+  'Lina',
+  'Louise',
+  'Lucas',
+  'Manon',
+  'Margaux',
+  'Maxime',
+  'Mathis',
+  'Nathan',
+  'Nina',
+  'Noah',
+  'Paul',
+  'Sarah',
+  'Theo',
+  'Tom',
+  'Zoe',
+] as const;
 
 export const DEFAULT_X01_BOT_LEVEL: X01BotLevel = 'AMATEUR';
 
@@ -22,8 +59,17 @@ export const getX01BotLevelDefinition = (level: X01BotLevel) =>
 
 export const formatX01BotAverageRange = (definition: X01BotLevelDefinition) =>
   definition.level === 'PRO'
-    ? `+ de ${definition.averageMin} de moyenne`
+    ? `+ de ${definition.averageDisplayFloor ?? definition.averageMin} de moyenne`
     : `${definition.averageMin} a ${definition.averageMax} de moyenne`;
+
+export const buildRandomX01BotName = (random: () => number = Math.random) => {
+  const safeIndex = Math.max(0, Math.min(
+    X01_BOT_FIRST_NAMES.length - 1,
+    Math.floor(random() * X01_BOT_FIRST_NAMES.length),
+  ));
+
+  return `[BOT] ${X01_BOT_FIRST_NAMES[safeIndex]}`;
+};
 
 export const isX01BotPlayer = (player: Player | undefined): player is Player & { isBot: true } =>
   Boolean(player?.isBot);

--- a/src/features/capital/capitalGameModel.ts
+++ b/src/features/capital/capitalGameModel.ts
@@ -1,0 +1,185 @@
+import type { CapitalDart, CapitalPlayerState, Player } from '../../../types';
+import { CAPITAL_TARGETS, evaluateCapitalRound, shouldResolveCapitalRound } from '../../../utils/capitalLogic';
+
+export type CapitalPendingResolution = {
+  darts: CapitalDart[];
+  playerId: string;
+  target: typeof CAPITAL_TARGETS[number];
+};
+
+export type CapitalHistorySnapshot = {
+  orderedPlayers: Player[];
+  states: CapitalPlayerState[];
+  currentPlayerIdx: number;
+  currentDarts: CapitalDart[];
+  pendingResolution: CapitalPendingResolution | null;
+};
+
+export type CapitalGameState = {
+  orderedPlayers: Player[];
+  states: CapitalPlayerState[];
+  currentPlayerIdx: number;
+  currentDarts: CapitalDart[];
+  history: CapitalHistorySnapshot[];
+  pendingResolution: CapitalPendingResolution | null;
+};
+
+export type CapitalGameAction =
+  | { type: 'sync_rotation'; orderedPlayers: Player[]; currentPlayerIdx: number }
+  | { type: 'set_starter'; currentPlayerIdx: number }
+  | { type: 'add_dart'; dart: CapitalDart }
+  | { type: 'resolve_round' }
+  | { type: 'undo' };
+
+const cloneCapitalDarts = (darts: CapitalDart[]) => darts.map((dart) => ({ ...dart }));
+
+const cloneCapitalHistory = (history: CapitalPlayerState['history']) => history.map((entry) => ({
+  ...entry,
+  darts: cloneCapitalDarts(entry.darts),
+}));
+
+const cloneCapitalPlayerStates = (states: CapitalPlayerState[]) => states.map((state) => ({
+  ...state,
+  history: cloneCapitalHistory(state.history),
+}));
+
+const cloneCapitalOrderedPlayers = (players: Player[]) => players.map((player) => ({ ...player }));
+
+const cloneCapitalSnapshot = (state: CapitalGameState): CapitalHistorySnapshot => ({
+  orderedPlayers: cloneCapitalOrderedPlayers(state.orderedPlayers),
+  states: cloneCapitalPlayerStates(state.states),
+  currentPlayerIdx: state.currentPlayerIdx,
+  currentDarts: cloneCapitalDarts(state.currentDarts),
+  pendingResolution: state.pendingResolution
+    ? {
+        ...state.pendingResolution,
+        darts: cloneCapitalDarts(state.pendingResolution.darts),
+      }
+    : null,
+});
+
+const createCapitalPlayerStates = (players: Player[]): CapitalPlayerState[] =>
+  players.map((player) => ({
+    id: player.id,
+    name: player.name,
+    score: 0,
+    targetIndex: 0,
+    history: [],
+  }));
+
+export const createInitialCapitalGameState = (orderedPlayers: Player[], currentPlayerIdx: number): CapitalGameState => ({
+  orderedPlayers: cloneCapitalOrderedPlayers(orderedPlayers),
+  states: createCapitalPlayerStates(orderedPlayers),
+  currentPlayerIdx,
+  currentDarts: [],
+  history: [],
+  pendingResolution: null,
+});
+
+export const capitalGameReducer = (state: CapitalGameState, action: CapitalGameAction): CapitalGameState => {
+  switch (action.type) {
+    case 'sync_rotation':
+      return {
+        ...state,
+        orderedPlayers: cloneCapitalOrderedPlayers(action.orderedPlayers),
+        currentPlayerIdx: action.currentPlayerIdx,
+      };
+    case 'set_starter':
+      return {
+        ...state,
+        currentPlayerIdx: action.currentPlayerIdx,
+      };
+    case 'add_dart': {
+      if (state.pendingResolution || state.currentDarts.length >= 3) {
+        return state;
+      }
+
+      const currentPlayerId = state.orderedPlayers[state.currentPlayerIdx]?.id ?? state.states[0]?.id;
+      const currentPlayer = state.states.find((entry) => entry.id === currentPlayerId);
+      if (!currentPlayer) {
+        return state;
+      }
+
+      const currentTarget = currentPlayer.targetIndex < CAPITAL_TARGETS.length
+        ? CAPITAL_TARGETS[currentPlayer.targetIndex]
+        : 'CAPITAL';
+      const nextDarts = [...state.currentDarts, { ...action.dart }];
+      const shouldResolve = shouldResolveCapitalRound(currentTarget, nextDarts);
+
+      return {
+        ...state,
+        currentDarts: nextDarts,
+        history: [...state.history, cloneCapitalSnapshot(state)],
+        pendingResolution: shouldResolve
+          ? {
+              darts: cloneCapitalDarts(nextDarts),
+              playerId: currentPlayer.id,
+              target: currentTarget,
+            }
+          : null,
+      };
+    }
+    case 'resolve_round': {
+      if (!state.pendingResolution) {
+        return state;
+      }
+
+      const { playerId, darts, target } = state.pendingResolution;
+      const playerIndex = state.states.findIndex((entry) => entry.id === playerId);
+      if (playerIndex < 0) {
+        return {
+          ...state,
+          pendingResolution: null,
+          currentDarts: [],
+        };
+      }
+
+      const nextStates = cloneCapitalPlayerStates(state.states);
+      const playerState = nextStates[playerIndex];
+      const { newScore, pointsScored, isSuccess } = evaluateCapitalRound(target, darts, playerState.score);
+
+      playerState.history.push({
+        target,
+        darts: cloneCapitalDarts(darts),
+        pointsScored,
+        isSuccess,
+      });
+      playerState.score = newScore;
+      playerState.targetIndex += 1;
+
+      return {
+        ...state,
+        states: nextStates,
+        currentPlayerIdx: (state.currentPlayerIdx + 1) % state.orderedPlayers.length,
+        currentDarts: [],
+        pendingResolution: null,
+      };
+    }
+    case 'undo': {
+      if (state.history.length === 0) {
+        return state;
+      }
+
+      const previousState = state.history[state.history.length - 1];
+      return {
+        orderedPlayers: cloneCapitalOrderedPlayers(previousState.orderedPlayers),
+        states: cloneCapitalPlayerStates(previousState.states),
+        currentPlayerIdx: previousState.currentPlayerIdx,
+        currentDarts: cloneCapitalDarts(previousState.currentDarts),
+        history: state.history.slice(0, -1),
+        pendingResolution: previousState.pendingResolution
+          ? {
+              ...previousState.pendingResolution,
+              darts: cloneCapitalDarts(previousState.pendingResolution.darts),
+            }
+          : null,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export const isCapitalGameOver = (states: CapitalPlayerState[]) => states.every((state) => state.targetIndex >= CAPITAL_TARGETS.length);
+
+export const sortCapitalResults = (states: CapitalPlayerState[]) => [...states].sort((a, b) => b.score - a.score);

--- a/src/features/cricket/cricketGameModel.ts
+++ b/src/features/cricket/cricketGameModel.ts
@@ -1,0 +1,142 @@
+import type { CricketMatchSummary, CricketPlayerState, CricketTarget, GameConfig, Player } from '../../../types';
+import { initCricketState } from '../../../utils/cricketLogic';
+
+export type CricketHistorySnapshot = {
+  states: CricketPlayerState[];
+  aggregateStats: CricketPlayerState[];
+  currentThrowerIdx: number;
+  turnDartsThrown: number;
+  orderedPlayers: Player[];
+  winnerId: string | null;
+};
+
+export type CricketCompetitor = {
+  id: string;
+  name: string;
+  memberNames: string[];
+};
+
+export const cloneCricketStates = (states: CricketPlayerState[]): CricketPlayerState[] =>
+  states.map((state) => ({
+    ...state,
+    marks: { ...state.marks },
+    history: state.history.map((entry) => ({ ...entry })),
+  }));
+
+export const clonePlayers = (players: Player[]): Player[] =>
+  players.map((player) => ({ ...player }));
+
+export const buildCricketHistorySnapshot = (
+  states: CricketPlayerState[],
+  aggregateStats: CricketPlayerState[],
+  currentThrowerIdx: number,
+  turnDartsThrown: number,
+  orderedPlayers: Player[],
+  winnerId: string | null,
+): CricketHistorySnapshot => ({
+  states: cloneCricketStates(states),
+  aggregateStats: cloneCricketStates(aggregateStats),
+  currentThrowerIdx,
+  turnDartsThrown,
+  orderedPlayers: clonePlayers(orderedPlayers),
+  winnerId,
+});
+
+export const buildCricketCompetitors = (players: Player[], isDoubles: boolean): CricketCompetitor[] => {
+  if (!isDoubles) {
+    return players.map((player) => ({
+      id: player.id,
+      name: player.name,
+      memberNames: [player.name],
+    }));
+  }
+
+  const groups = players.reduce<Record<string, string[]>>((accumulator, player) => {
+    accumulator[player.teamId] = accumulator[player.teamId] || [];
+    accumulator[player.teamId].push(player.name);
+    return accumulator;
+  }, {});
+
+  return Object.entries(groups).map(([teamId, memberNames], index) => ({
+    id: teamId,
+    name: `Equipe ${index + 1}`,
+    memberNames,
+  }));
+};
+
+export const initAggregateCricketStats = (competitors: CricketCompetitor[]): CricketPlayerState[] =>
+  competitors.map((competitor) => ({
+    ...initCricketState([{ id: competitor.id, name: competitor.name, teamId: competitor.id }])[0],
+  }));
+
+export const appendAggregateCricketHit = (
+  previous: CricketPlayerState[],
+  competitorId: string,
+  target: CricketTarget | null,
+  multiplier: 1 | 2 | 3,
+  pointsScored: number,
+  isMiss: boolean,
+) =>
+  previous.map((entry) => {
+    if (entry.id !== competitorId) {
+      return entry;
+    }
+
+    const nextMarks = { ...entry.marks };
+    if (target !== null) {
+      nextMarks[target] += multiplier;
+    }
+
+    return {
+      ...entry,
+      score: entry.score + pointsScored,
+      dartsThrown: entry.dartsThrown + 1,
+      marks: nextMarks,
+      history: [
+        ...entry.history,
+        {
+          target,
+          multiplier,
+          isMiss,
+          pointsScored,
+        },
+      ],
+    };
+  });
+
+export const buildCricketMatchSummary = (
+  competitors: CricketPlayerState[],
+  winnerId: string,
+  config: GameConfig,
+  memberNamesByCompetitor: Record<string, string[]>,
+  legsWon: Record<string, number>,
+  setsWon: Record<string, number>,
+  currentSetLegsWon: Record<string, number>,
+): CricketMatchSummary => ({
+  competitors,
+  legsWon,
+  setsWon,
+  currentSetLegsWon,
+  winnerId,
+  config,
+  isDoubles: config.isDoubles,
+  memberNamesByCompetitor,
+});
+
+export const advanceCricketTurn = (turnDartsThrown: number, orderedPlayersLength: number, dartsAdded = 1) => {
+  const nextDartsThrown = turnDartsThrown + dartsAdded;
+
+  if (nextDartsThrown >= 3) {
+    return {
+      nextTurnDartsThrown: 0,
+      shouldAdvanceThrower: true,
+      nextThrowerOffset: orderedPlayersLength > 0 ? 1 % orderedPlayersLength : 0,
+    };
+  }
+
+  return {
+    nextTurnDartsThrown: nextDartsThrown,
+    shouldAdvanceThrower: false,
+    nextThrowerOffset: 0,
+  };
+};

--- a/src/features/game-setup/setupModel.ts
+++ b/src/features/game-setup/setupModel.ts
@@ -1,6 +1,6 @@
 import type { GameConfig, InOutRule, MatchMode, Player, X01BotLevel } from '../../../types';
 import type { GameType } from '../../../utils/arenaFlow';
-import { DEFAULT_X01_BOT_LEVEL } from '../../domain/x01Bot/x01Bot';
+import { buildRandomX01BotName, DEFAULT_X01_BOT_LEVEL } from '../../domain/x01Bot/x01Bot';
 
 export interface SetupState {
   startingScore: number;
@@ -98,7 +98,7 @@ export const normalizeSetupState = (state: SetupState, gameType: GameType): Setu
   if (nextState.playAgainstBot && !nextState.isDoubles) {
     nextState = {
       ...nextState,
-      playerNames: [nextState.playerNames[0] || '', nextState.playerNames[1] || 'Robot'],
+      playerNames: [nextState.playerNames[0] || '', nextState.playerNames[1] || ''],
       startingPlayerIndex: Math.min(nextState.startingPlayerIndex, 1),
     };
   }
@@ -365,6 +365,7 @@ export const buildSetupPlayers = (params: {
   team2Names: string[];
   playAgainstBot?: boolean;
   botLevel?: X01BotLevel;
+  random?: () => number;
 }) => {
   if (params.isDoubles) {
     const p1 = { id: 't1p1', name: params.team1Names[0].trim() || 'Joueur 1', teamId: 'team1' };
@@ -384,7 +385,7 @@ export const buildSetupPlayers = (params: {
       },
       {
         id: 'p2',
-        name: params.playerNames[1].trim() || 'Robot',
+        name: buildRandomX01BotName(params.random),
         teamId: 'p2',
         isBot: true,
         botLevel,

--- a/src/features/game-setup/setupViewModel.ts
+++ b/src/features/game-setup/setupViewModel.ts
@@ -1,0 +1,121 @@
+import type { GameType } from '../../../utils/arenaFlow';
+import type { InOutRule, MatchMode, X01BotLevel } from '../../../types';
+import { getGameName, getMatchModeLabel, getRuleLabel } from './setupPresentation';
+
+export type SetupSummaryEntry = {
+  label: string;
+  value: string | number;
+};
+
+export const supportsDoublesMode = (gameType: GameType) => (
+  gameType === 'X01' || gameType === 'CRICKET' || gameType === 'TRIATHLON'
+);
+
+export const canEnableBotOpponent = (gameType: GameType, isDoubles: boolean) => (
+  gameType === 'X01' && !isDoubles
+);
+
+export const getSetupPlayerCountOptions = (gameType: GameType) => {
+  if (gameType === 'CRICKET') {
+    return [2, 3];
+  }
+
+  if (gameType === 'KILLER' || gameType === 'GOTCHA') {
+    return [2, 3, 4, 5, 6];
+  }
+
+  if (gameType === 'TRIATHLON') {
+    return [2];
+  }
+
+  if (gameType === 'X01') {
+    return [1, 2];
+  }
+
+  return [1, 2, 3, 4];
+};
+
+export const buildTeamStarterOptions = (teamId: 'team1' | 'team2', playerNames: string[]) => {
+  const defaultLabelOffset = teamId === 'team1' ? 1 : 3;
+  const playerPrefix = teamId === 'team1' ? 't1p' : 't2p';
+
+  return [0, 1].map((index) => ({
+    id: `${playerPrefix}${index + 1}`,
+    label: playerNames[index].trim() || `Joueur ${defaultLabelOffset + index}`,
+  }));
+};
+
+export const buildSetupSummaryEntries = (params: {
+  gameType: GameType;
+  startingScore: number;
+  matchMode: MatchMode;
+  legsToWin: number;
+  setsToWin: number;
+  cricketRounds: number;
+  isDoubles: boolean;
+  playerCount: number;
+  checkIn: InOutRule;
+  checkOut: InOutRule;
+}): SetupSummaryEntry[] => {
+  const entries: SetupSummaryEntry[] = [
+    { label: 'Jeu', value: getGameName(params.gameType) },
+  ];
+
+  if (params.gameType === 'TRIATHLON') {
+    entries.push(
+      { label: 'Ordre Des Jeux', value: 'Capital / Cricket / 501' },
+      { label: 'Format', value: params.isDoubles ? 'Doublettes' : 'Individuel' },
+    );
+    return entries;
+  }
+
+  if (params.gameType === 'X01' || params.gameType === 'CRICKET' || params.gameType === 'GOTCHA') {
+    if (params.gameType === 'X01' || params.gameType === 'GOTCHA') {
+      entries.push({
+        label: params.gameType === 'GOTCHA' ? 'Score Cible' : 'Score De Depart',
+        value: params.startingScore,
+      });
+    }
+
+    if (params.gameType === 'X01') {
+      entries.push({ label: 'Format', value: getMatchModeLabel(params.matchMode) });
+    }
+
+    if (params.gameType === 'CRICKET') {
+      entries.push(
+        { label: 'Nombre De Tours', value: params.cricketRounds },
+        { label: 'Nombre De Joueurs', value: params.isDoubles ? 4 : params.playerCount },
+      );
+    }
+
+    if (params.gameType === 'GOTCHA') {
+      entries.push({ label: 'Nombre De Joueurs', value: params.playerCount });
+    }
+
+    if (params.gameType === 'X01' && params.matchMode === 'LEGS') {
+      entries.push({ label: 'Manches Pour Gagner', value: params.legsToWin });
+    }
+
+    if (params.gameType === 'X01' && params.matchMode === 'SETS') {
+      entries.push(
+        { label: 'Sets Pour Gagner', value: params.setsToWin },
+        { label: 'Manches Par Set', value: params.legsToWin },
+      );
+    }
+
+    if (params.gameType === 'X01') {
+      entries.push({
+        label: 'Ouverture / Fermeture',
+        value: `${getRuleLabel(params.checkIn)} / ${getRuleLabel(params.checkOut)}`,
+      });
+    }
+
+    entries.push({ label: 'Mode', value: params.isDoubles ? 'Doublettes' : 'Simple' });
+  }
+
+  return entries;
+};
+
+export const getBotLevelLabel = (levels: Array<{ level: X01BotLevel; label: string }>, botLevel: X01BotLevel) => (
+  levels.find((definition) => definition.level === botLevel)?.label ?? 'Amateur'
+);

--- a/src/features/x01/scoring/botVictoryPreview.ts
+++ b/src/features/x01/scoring/botVictoryPreview.ts
@@ -1,0 +1,37 @@
+import type { MatchState } from '../../../../types';
+
+type ResolveBotVictoryPreviewParams = {
+  previousMatch: MatchState;
+  nextMatch: MatchState;
+  currentPlayerTeamId: string;
+  showWinnerScreen: boolean;
+};
+
+type BotVictoryPreviewResolution = {
+  hasBotWonLeg: boolean;
+  hasBotWonMatch: boolean;
+  previewKind: 'leg' | 'match' | null;
+};
+
+export const resolveBotVictoryPreview = ({
+  previousMatch,
+  nextMatch,
+  currentPlayerTeamId,
+  showWinnerScreen,
+}: ResolveBotVictoryPreviewParams): BotVictoryPreviewResolution => {
+  const advancedToNextLeg =
+    !showWinnerScreen
+    && nextMatch.completedLegs.length > previousMatch.completedLegs.length
+    && nextMatch.currentLeg.history.length === 0;
+  const completedLeg = advancedToNextLeg
+    ? nextMatch.completedLegs[nextMatch.completedLegs.length - 1]
+    : null;
+  const hasBotWonMatch = showWinnerScreen && nextMatch.matchWinnerId === currentPlayerTeamId;
+  const hasBotWonLeg = advancedToNextLeg && completedLeg?.winnerId === currentPlayerTeamId;
+
+  return {
+    hasBotWonLeg,
+    hasBotWonMatch,
+    previewKind: hasBotWonMatch ? 'match' : hasBotWonLeg ? 'leg' : null,
+  };
+};

--- a/src/features/x01/voice/audioContextManager.ts
+++ b/src/features/x01/voice/audioContextManager.ts
@@ -1,0 +1,153 @@
+import type { MutableRefObject } from 'react';
+
+import { downsampleToLinear16 } from './voicePcm';
+
+export type AudioCaptureRefs = {
+  mediaStreamRef: MutableRefObject<MediaStream | null>;
+  audioContextRef: MutableRefObject<AudioContext | null>;
+  sourceRef: MutableRefObject<MediaStreamAudioSourceNode | null>;
+  workletNodeRef: MutableRefObject<AudioWorkletNode | null>;
+  gainRef: MutableRefObject<GainNode | null>;
+  audioWorkletLoadedRef: MutableRefObject<boolean>;
+  bufferedPcmChunksRef: MutableRefObject<Int16Array[]>;
+};
+
+type EnsureAudioCaptureReadyParams = {
+  refs: AudioCaptureRefs;
+  mediaStream: MediaStream;
+  onAudioChunk: (pcm: Int16Array) => void;
+  onRuntimeFailure: () => void;
+  onReady: () => void;
+  pcmCaptureWorkletPath: string;
+  targetSampleRate: number;
+  logTiming: (step: string, extra?: Record<string, unknown>) => void;
+};
+
+export function createBrowserAudioContext(): AudioContext {
+  const BrowserAudioContext = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!BrowserAudioContext) {
+    throw new Error('AudioContext non supporte sur ce navigateur.');
+  }
+
+  return new BrowserAudioContext();
+}
+
+export function cleanupAudioResources(refs: AudioCaptureRefs, options?: { closeContext?: boolean }) {
+  try {
+    refs.workletNodeRef.current?.port.close();
+  } catch {
+    // ignore port close failures
+  }
+  try {
+    refs.workletNodeRef.current?.disconnect();
+  } catch {
+    // ignore disconnect failures
+  }
+  try {
+    refs.sourceRef.current?.disconnect();
+  } catch {
+    // ignore disconnect failures
+  }
+  try {
+    refs.gainRef.current?.disconnect();
+  } catch {
+    // ignore disconnect failures
+  }
+  refs.workletNodeRef.current = null;
+  refs.sourceRef.current = null;
+  refs.gainRef.current = null;
+  refs.bufferedPcmChunksRef.current = [];
+
+  try {
+    refs.mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+  } catch {
+    // ignore track stop failures
+  }
+  refs.mediaStreamRef.current = null;
+
+  if (options?.closeContext && refs.audioContextRef.current) {
+    void refs.audioContextRef.current.close().catch(() => {
+      // ignore close failures
+    });
+    refs.audioContextRef.current = null;
+    refs.audioWorkletLoadedRef.current = false;
+  }
+}
+
+export async function ensureAudioCaptureReady({
+  refs,
+  mediaStream,
+  onAudioChunk,
+  onRuntimeFailure,
+  onReady,
+  pcmCaptureWorkletPath,
+  targetSampleRate,
+  logTiming,
+}: EnsureAudioCaptureReadyParams) {
+  let audioContext = refs.audioContextRef.current;
+  if (!audioContext) {
+    audioContext = createBrowserAudioContext();
+    refs.audioContextRef.current = audioContext;
+    logTiming('audio-context-created', { sampleRate: audioContext.sampleRate });
+  }
+
+  if (audioContext.state !== 'running') {
+    await audioContext.resume();
+    logTiming('audio-context-resumed', { state: audioContext.state });
+  } else {
+    logTiming('audio-context-already-running', { state: audioContext.state });
+  }
+
+  if (!audioContext.audioWorklet) {
+    throw new Error('AudioWorklet non supporte sur ce navigateur.');
+  }
+
+  if (!refs.audioWorkletLoadedRef.current) {
+    await audioContext.audioWorklet.addModule(pcmCaptureWorkletPath);
+    refs.audioWorkletLoadedRef.current = true;
+    logTiming('audio-worklet-loaded');
+  }
+
+  cleanupAudioResources(refs);
+  refs.mediaStreamRef.current = mediaStream;
+
+  const source = audioContext.createMediaStreamSource(mediaStream);
+  const workletNode = new AudioWorkletNode(audioContext, 'pcm-capture-processor', {
+    channelCount: 1,
+    channelCountMode: 'explicit',
+    numberOfInputs: 1,
+    numberOfOutputs: 1,
+    outputChannelCount: [1],
+  });
+  const gain = audioContext.createGain();
+  gain.gain.value = 0;
+  const sink = audioContext.createGain();
+  sink.gain.value = 0;
+
+  refs.sourceRef.current = source;
+  refs.workletNodeRef.current = workletNode;
+  refs.gainRef.current = gain;
+
+  workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
+    try {
+      const input = event.data;
+      if (!(input instanceof Float32Array) || input.length === 0) {
+        return;
+      }
+
+      const pcm = downsampleToLinear16(input, audioContext.sampleRate, targetSampleRate);
+      if (pcm.byteLength > 0) {
+        onAudioChunk(pcm);
+      }
+    } catch {
+      onRuntimeFailure();
+    }
+  };
+
+  source.connect(workletNode);
+  workletNode.connect(gain);
+  gain.connect(sink);
+  sink.connect(audioContext.destination);
+  logTiming('audio-graph-ready');
+  onReady();
+}

--- a/src/features/x01/voice/dartsSpeechTypes.ts
+++ b/src/features/x01/voice/dartsSpeechTypes.ts
@@ -1,4 +1,5 @@
 export type VoiceScoringStatus = 'idle' | 'listening' | 'processing' | 'error';
+export type VoiceRuntimeIssue = 'microphone' | 'token' | 'connection' | 'timeout' | 'transcript' | 'audio';
 
 export type DartMultiplier = 'single' | 'double' | 'triple';
 export type DartsParseStatus = 'valid' | 'ambiguous' | 'invalid';
@@ -54,4 +55,6 @@ export interface VoiceScoreProposalState {
   transcript: string;
   result: DartsSpeechParseResult;
   trigger: DeepgramUtteranceTrigger;
+  guidance?: string | null;
+  prefillScore?: string | null;
 }

--- a/src/features/x01/voice/deepgramConnectionManager.ts
+++ b/src/features/x01/voice/deepgramConnectionManager.ts
@@ -1,0 +1,47 @@
+import { DeepgramClient } from '@deepgram/sdk';
+import type { MutableRefObject } from 'react';
+
+import type { DeepgramLiveConnection, DeepgramMessage } from './deepgramLiveTypes';
+import { buildDeepgramListenConfig } from './voiceConfig';
+
+export type DeepgramConnectionRefs = {
+  connectionRef: MutableRefObject<DeepgramLiveConnection | null>;
+  socketReadyRef: MutableRefObject<boolean>;
+};
+
+type DeepgramConnectionHandlers = {
+  onOpen: () => void;
+  onMessage: (message: DeepgramMessage) => void;
+  onError: (error: Error) => void;
+  onClose: (event: { code: number; reason: string }) => void;
+};
+
+export function cleanupDeepgramConnection(refs: DeepgramConnectionRefs) {
+  if (refs.connectionRef.current) {
+    refs.connectionRef.current.close();
+  }
+  refs.connectionRef.current = null;
+  refs.socketReadyRef.current = false;
+}
+
+export async function connectDeepgramLive(
+  refs: DeepgramConnectionRefs,
+  accessToken: string,
+  handlers: DeepgramConnectionHandlers,
+) {
+  const client = new DeepgramClient({ accessToken });
+  const connection = await client.listen.v1.connect(
+    buildDeepgramListenConfig(`Bearer ${accessToken}`),
+  ) as DeepgramLiveConnection;
+  refs.connectionRef.current = connection;
+
+  connection.on('open', handlers.onOpen);
+  connection.on('message', handlers.onMessage);
+  connection.on('error', handlers.onError);
+  connection.on('close', handlers.onClose);
+
+  connection.connect();
+  await connection.waitForOpen();
+
+  return connection;
+}

--- a/src/features/x01/voice/useDeepgramStreaming.ts
+++ b/src/features/x01/voice/useDeepgramStreaming.ts
@@ -1,6 +1,5 @@
 // Spec: spec:counter/voice-scoring-reliability
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { DeepgramClient } from '@deepgram/sdk';
 
 import { fetchDeepgramAccessToken } from './deepgramClient';
 import type {
@@ -9,17 +8,15 @@ import type {
   VoiceScoringStatus,
 } from './dartsSpeechTypes';
 import type { DeepgramLiveConnection } from './deepgramLiveTypes';
-import { buildDeepgramListenConfig, VOICE_SCORING_TIMEOUT_MS } from './voiceConfig';
-import { downsampleToLinear16 } from './voicePcm';
+import { VOICE_SCORING_TIMEOUT_MS } from './voiceConfig';
+import { cleanupAudioResources, createBrowserAudioContext, ensureAudioCaptureReady as ensureAudioCaptureGraphReady } from './audioContextManager';
+import { cleanupDeepgramConnection, connectDeepgramLive } from './deepgramConnectionManager';
+import { logVoiceDebug, logVoiceError } from './voiceStreamingLogger';
+import { appendBufferedPcmChunk, buildDeepgramUtterance, describeCaughtError, type FinalChunk } from './voiceStreamingModel';
 
 type UseDeepgramStreamingOptions = {
   enabled: boolean;
   onUtterance: (payload: DeepgramUtterance) => void;
-};
-
-type FinalChunk = {
-  transcript: string;
-  confidence: number;
 };
 
 type StartTimings = {
@@ -29,7 +26,6 @@ type StartTimings = {
 
 const TARGET_SAMPLE_RATE = 16000;
 const MAX_BUFFERED_PCM_CHUNKS = 24;
-const VOICE_DEBUG_PREFIX = '[voice-scoring]';
 const PCM_CAPTURE_WORKLET_PATH = '/pcmCaptureWorklet.js';
 
 export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStreamingOptions) {
@@ -88,7 +84,7 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
 
     try {
       audioContextRef.current = createBrowserAudioContext();
-      console.debug(`${VOICE_DEBUG_PREFIX} pre-created audio context`, {
+      logVoiceDebug('pre-created audio context', {
         state: audioContextRef.current.state,
         sampleRate: audioContextRef.current.sampleRate,
       });
@@ -105,53 +101,19 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
   }, []);
 
   const cleanupAudio = useCallback((options?: { closeContext?: boolean }) => {
-    try {
-      workletNodeRef.current?.port.close();
-    } catch {
-      // ignore port close failures
-    }
-    try {
-      workletNodeRef.current?.disconnect();
-    } catch {
-      // ignore disconnect failures
-    }
-    try {
-      sourceRef.current?.disconnect();
-    } catch {
-      // ignore disconnect failures
-    }
-    try {
-      gainRef.current?.disconnect();
-    } catch {
-      // ignore disconnect failures
-    }
-    workletNodeRef.current = null;
-    sourceRef.current = null;
-    gainRef.current = null;
-    bufferedPcmChunksRef.current = [];
-
-    try {
-      mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
-    } catch {
-      // ignore track stop failures
-    }
-    mediaStreamRef.current = null;
-
-    if (options?.closeContext && audioContextRef.current) {
-      void audioContextRef.current.close().catch(() => {
-        // ignore close failures
-      });
-      audioContextRef.current = null;
-      audioWorkletLoadedRef.current = false;
-    }
+    cleanupAudioResources({
+      mediaStreamRef,
+      audioContextRef,
+      sourceRef,
+      workletNodeRef,
+      gainRef,
+      audioWorkletLoadedRef,
+      bufferedPcmChunksRef,
+    }, options);
   }, []);
 
   const cleanupSocket = useCallback(() => {
-    if (connectionRef.current) {
-      connectionRef.current.close();
-    }
-    connectionRef.current = null;
-    socketReadyRef.current = false;
+    cleanupDeepgramConnection({ connectionRef, socketReadyRef });
   }, []);
 
   const flushBufferedAudio = useCallback(() => {
@@ -172,15 +134,15 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       return;
     }
 
-    if (bufferedPcmChunksRef.current.length >= MAX_BUFFERED_PCM_CHUNKS) {
-      bufferedPcmChunksRef.current.shift();
-    }
-
-    bufferedPcmChunksRef.current.push(pcm.slice());
+    bufferedPcmChunksRef.current = appendBufferedPcmChunk(
+      bufferedPcmChunksRef.current,
+      pcm,
+      MAX_BUFFERED_PCM_CHUNKS,
+    );
   }, []);
 
   const handleRuntimeFailure = useCallback((message: string) => {
-    console.error(`${VOICE_DEBUG_PREFIX} runtime failure`, {
+    logVoiceError('runtime failure', {
       message,
       state: stateRef.current,
     });
@@ -206,30 +168,20 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       return;
     }
 
-    const finalTranscript = finalChunksRef.current
-      .map((chunk) => chunk.transcript.trim())
-      .filter(Boolean)
-      .join(' ')
-      .trim();
+    const utterance = buildDeepgramUtterance(
+      finalChunksRef.current,
+      liveTranscriptRef.current,
+      liveConfidenceRef.current,
+      trigger,
+    );
 
-    const transcript = finalTranscript || liveTranscriptRef.current.trim();
-
-    if (!transcript) {
+    if (!utterance) {
       return;
     }
 
-    const totalConfidence = finalChunksRef.current.reduce((sum, chunk) => sum + chunk.confidence, 0);
-    const confidence = finalChunksRef.current.length
-      ? totalConfidence / finalChunksRef.current.length
-      : liveConfidenceRef.current;
-
     try {
       utteranceClosedRef.current = true;
-      onUtterance({
-        transcript,
-        confidence,
-        trigger,
-      });
+      onUtterance(utterance);
       finalChunksRef.current = [];
       setLiveTranscript('');
       setState('processing');
@@ -255,83 +207,35 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
   }, [clearListeningTimeout, reset]);
 
   const ensureAudioCaptureReady = useCallback(async (mediaStream: MediaStream, timings: StartTimings) => {
-    let audioContext = audioContextRef.current;
-    if (!audioContext) {
-      audioContext = createBrowserAudioContext();
-      audioContextRef.current = audioContext;
-      timings.log('audio-context-created', { sampleRate: audioContext.sampleRate });
-    }
-
-    if (audioContext.state !== 'running') {
-      await audioContext.resume();
-      timings.log('audio-context-resumed', { state: audioContext.state });
-    } else {
-      timings.log('audio-context-already-running', { state: audioContext.state });
-    }
-
-    if (!audioContext.audioWorklet) {
-      throw new Error('AudioWorklet non supporte sur ce navigateur.');
-    }
-
-    if (!audioWorkletLoadedRef.current) {
-      await audioContext.audioWorklet.addModule(PCM_CAPTURE_WORKLET_PATH);
-      audioWorkletLoadedRef.current = true;
-      timings.log('audio-worklet-loaded');
-    }
-
-    cleanupAudio();
-    mediaStreamRef.current = mediaStream;
-
-    const source = audioContext.createMediaStreamSource(mediaStream);
-    const workletNode = new AudioWorkletNode(audioContext, 'pcm-capture-processor', {
-      channelCount: 1,
-      channelCountMode: 'explicit',
-      numberOfInputs: 1,
-      numberOfOutputs: 1,
-      outputChannelCount: [1],
+    await ensureAudioCaptureGraphReady({
+      refs: {
+        mediaStreamRef,
+        audioContextRef,
+        sourceRef,
+        workletNodeRef,
+        gainRef,
+        audioWorkletLoadedRef,
+        bufferedPcmChunksRef,
+      },
+      mediaStream,
+      onAudioChunk: sendOrBufferAudioChunk,
+      onRuntimeFailure: () => handleRuntimeFailure('Impossible de streamer l audio micro.'),
+      onReady: () => setState('listening'),
+      pcmCaptureWorkletPath: PCM_CAPTURE_WORKLET_PATH,
+      targetSampleRate: TARGET_SAMPLE_RATE,
+      logTiming: timings.log,
     });
-    const gain = audioContext.createGain();
-    gain.gain.value = 0;
-    const sink = audioContext.createGain();
-    sink.gain.value = 0;
-
-    sourceRef.current = source;
-    workletNodeRef.current = workletNode;
-    gainRef.current = gain;
-
-    workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
-      try {
-        const input = event.data;
-        if (!(input instanceof Float32Array) || input.length === 0) {
-          return;
-        }
-
-        const pcm = downsampleToLinear16(input, audioContext.sampleRate, TARGET_SAMPLE_RATE);
-        if (pcm.byteLength > 0) {
-          sendOrBufferAudioChunk(pcm);
-        }
-      } catch {
-        handleRuntimeFailure('Impossible de streamer l audio micro.');
-      }
-    };
-
-    source.connect(workletNode);
-    workletNode.connect(gain);
-    gain.connect(sink);
-    sink.connect(audioContext.destination);
-    timings.log('audio-graph-ready');
-    setState('listening');
   }, [cleanupAudio, handleRuntimeFailure, sendOrBufferAudioChunk]);
 
   const start = useCallback(async () => {
     const timings = createStartTimings();
-    console.debug(`${VOICE_DEBUG_PREFIX} start requested`, {
+    logVoiceDebug('start requested', {
       enabled,
       state: stateRef.current,
     });
 
     if (!enabled || state === 'listening') {
-      console.debug(`${VOICE_DEBUG_PREFIX} start ignored`, {
+      logVoiceDebug('start ignored', {
         enabled,
         state: stateRef.current,
       });
@@ -343,7 +247,7 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     setState('processing');
 
     try {
-      console.debug(`${VOICE_DEBUG_PREFIX} requesting token and microphone`);
+      logVoiceDebug('requesting token and microphone');
       const tokenPromise = fetchDeepgramAccessToken().then((token) => {
         timings.log('token-ready');
         return token;
@@ -367,20 +271,104 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       const audioSetupPromise = ensureAudioCaptureReady(mediaStream, timings);
       const { accessToken } = await tokenPromise;
 
-      console.debug(`${VOICE_DEBUG_PREFIX} token and microphone ready`, {
+      logVoiceDebug('token and microphone ready', {
         hasAccessToken: Boolean(accessToken),
         audioTracks: mediaStream.getAudioTracks().length,
       });
-      const client = new DeepgramClient({ accessToken });
-      const connection = await client.listen.v1.connect(
-        buildDeepgramListenConfig(`Bearer ${accessToken}`),
-      ) as DeepgramLiveConnection;
-      connectionRef.current = connection;
+      const connection = await connectDeepgramLive(
+        { connectionRef, socketReadyRef },
+        accessToken,
+        {
+          onOpen: () => {
+            logVoiceDebug('websocket open');
+            socketReadyRef.current = true;
+            timings.log('websocket-open');
+            flushBufferedAudio();
+          },
+          onMessage: (payload) => {
+            try {
+              logVoiceDebug('websocket message', {
+                type: payload.type,
+                isFinal: 'is_final' in payload ? payload.is_final : undefined,
+                speechFinal: 'speech_final' in payload ? payload.speech_final : undefined,
+              });
+
+              if (payload.type === 'SpeechStarted') {
+                utteranceClosedRef.current = false;
+                setState('listening');
+                return;
+              }
+
+              if (payload.type === 'UtteranceEnd') {
+                emitUtterance('utterance_end');
+                return;
+              }
+
+              if (payload.type === 'Error') {
+                logVoiceError('deepgram error payload', {
+                  error: payload.error || 'Unknown Deepgram error',
+                });
+                handleRuntimeFailure(payload.error || 'Erreur Deepgram.');
+                return;
+              }
+
+              if (payload.type !== 'Results') {
+                return;
+              }
+
+              const alternative = payload.channel?.alternatives?.[0];
+              const transcript = alternative?.transcript?.trim() || '';
+              if (!transcript) {
+                return;
+              }
+
+              if (payload.is_final) {
+                finalChunksRef.current.push({
+                  transcript,
+                  confidence: alternative?.confidence ?? 0,
+                });
+                liveConfidenceRef.current = alternative?.confidence ?? 0;
+                setLiveTranscript(transcript);
+              } else {
+                utteranceClosedRef.current = false;
+                liveConfidenceRef.current = alternative?.confidence ?? 0;
+                setLiveTranscript(transcript);
+              }
+
+              if (payload.speech_final) {
+                emitUtterance('speech_final');
+              }
+            } catch (error) {
+              logVoiceError('invalid websocket message', {
+                message: describeCaughtError(error),
+                type: payload.type,
+              });
+              handleRuntimeFailure('Message vocal invalide ou illisible.');
+            }
+          },
+          onError: (caughtError) => {
+            logVoiceError('websocket error event', {
+              message: describeCaughtError(caughtError),
+            });
+            setError('Connexion vocale indisponible.');
+            setState('error');
+          },
+          onClose: () => {
+            logVoiceDebug('websocket close', {
+              previousState: stateRef.current,
+            });
+            clearListeningTimeout();
+            cleanupAudio();
+            connectionRef.current = null;
+            setState((current) => (current === 'error' ? current : 'idle'));
+          },
+        },
+      );
       timings.log('websocket-client-created');
 
       clearListeningTimeout();
       listeningTimeoutRef.current = window.setTimeout(() => {
-        console.debug(`${VOICE_DEBUG_PREFIX} listening timeout reached`, {
+        logVoiceDebug('listening timeout reached', {
           timeoutMs: VOICE_SCORING_TIMEOUT_MS,
           finalChunks: finalChunksRef.current.length,
           liveTranscript: liveTranscriptRef.current,
@@ -403,95 +391,12 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
         setState((current) => (current === 'error' ? current : 'idle'));
       }, VOICE_SCORING_TIMEOUT_MS);
 
-      connection.on('open', async () => {
-        console.debug(`${VOICE_DEBUG_PREFIX} websocket open`);
-        socketReadyRef.current = true;
-        timings.log('websocket-open');
-        flushBufferedAudio();
-      });
-
-      connection.on('message', (payload) => {
-        try {
-          console.debug(`${VOICE_DEBUG_PREFIX} websocket message`, {
-            type: payload.type,
-            isFinal: 'is_final' in payload ? payload.is_final : undefined,
-            speechFinal: 'speech_final' in payload ? payload.speech_final : undefined,
-          });
-
-          if (payload.type === 'SpeechStarted') {
-            utteranceClosedRef.current = false;
-            setState('listening');
-            return;
-          }
-
-          if (payload.type === 'UtteranceEnd') {
-            emitUtterance('utterance_end');
-            return;
-          }
-
-          if (payload.type === 'Error') {
-            console.error(`${VOICE_DEBUG_PREFIX} deepgram error payload`, payload);
-            handleRuntimeFailure(payload.error || 'Erreur Deepgram.');
-            return;
-          }
-
-          if (payload.type !== 'Results') {
-            return;
-          }
-
-          const alternative = payload.channel?.alternatives?.[0];
-          const transcript = alternative?.transcript?.trim() || '';
-          if (!transcript) {
-            return;
-          }
-
-          if (payload.is_final) {
-            finalChunksRef.current.push({
-              transcript,
-              confidence: alternative?.confidence ?? 0,
-            });
-            liveConfidenceRef.current = alternative?.confidence ?? 0;
-            setLiveTranscript(transcript);
-          } else {
-            utteranceClosedRef.current = false;
-            liveConfidenceRef.current = alternative?.confidence ?? 0;
-            setLiveTranscript(transcript);
-          }
-
-          if (payload.speech_final) {
-            emitUtterance('speech_final');
-          }
-        } catch (error) {
-          console.error(`${VOICE_DEBUG_PREFIX} invalid websocket message`, {
-            error,
-            raw: payload,
-          });
-          handleRuntimeFailure('Message vocal invalide ou illisible.');
-        }
-      });
-
-      connection.on('error', (caughtError) => {
-        console.error(`${VOICE_DEBUG_PREFIX} websocket error event`, caughtError);
-        setError('Connexion vocale indisponible.');
-        setState('error');
-      });
-
-      connection.on('close', () => {
-        console.debug(`${VOICE_DEBUG_PREFIX} websocket close`, {
-          previousState: stateRef.current,
-        });
-        clearListeningTimeout();
-        cleanupAudio();
-        connectionRef.current = null;
-        setState((current) => (current === 'error' ? current : 'idle'));
-      });
-
-      connection.connect();
-      await connection.waitForOpen();
       await audioSetupPromise;
       timings.log('start-ready');
     } catch (caughtError) {
-      console.error(`${VOICE_DEBUG_PREFIX} start failed`, caughtError);
+      logVoiceError('start failed', {
+        message: describeCaughtError(caughtError),
+      });
       const message = caughtError instanceof Error ? caughtError.message : 'Impossible de lancer l ecoute.';
       handleRuntimeFailure(message);
     }
@@ -530,22 +435,13 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
   };
 }
 
-function createBrowserAudioContext(): AudioContext {
-  const BrowserAudioContext = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-  if (!BrowserAudioContext) {
-    throw new Error('AudioContext non supporte sur ce navigateur.');
-  }
-
-  return new BrowserAudioContext();
-}
-
 function createStartTimings(): StartTimings {
   const startAt = performance.now();
 
   return {
     startAt,
     log(step, extra) {
-      console.debug(`${VOICE_DEBUG_PREFIX} timing`, {
+      logVoiceDebug('timing', {
         step,
         elapsedMs: Math.round(performance.now() - startAt),
         ...extra,

--- a/src/features/x01/voice/useDeepgramStreaming.ts
+++ b/src/features/x01/voice/useDeepgramStreaming.ts
@@ -5,17 +5,26 @@ import { fetchDeepgramAccessToken } from './deepgramClient';
 import type {
   DeepgramUtterance,
   DeepgramUtteranceTrigger,
+  VoiceRuntimeIssue,
   VoiceScoringStatus,
 } from './dartsSpeechTypes';
 import type { DeepgramLiveConnection } from './deepgramLiveTypes';
 import { VOICE_SCORING_TIMEOUT_MS } from './voiceConfig';
 import { cleanupAudioResources, createBrowserAudioContext, ensureAudioCaptureReady as ensureAudioCaptureGraphReady } from './audioContextManager';
 import { cleanupDeepgramConnection, connectDeepgramLive } from './deepgramConnectionManager';
+import {
+  buildVoiceRuntimeIssueMessage,
+  createNextVoiceAttempt,
+  isVoiceAttemptCurrent,
+  resolveVoiceStartFailureCause,
+  type VoiceAttempt,
+} from './voiceSessionModel';
 import { logVoiceDebug, logVoiceError } from './voiceStreamingLogger';
 import { appendBufferedPcmChunk, buildDeepgramUtterance, describeCaughtError, type FinalChunk } from './voiceStreamingModel';
 
 type UseDeepgramStreamingOptions = {
   enabled: boolean;
+  sessionKey: string;
   onUtterance: (payload: DeepgramUtterance) => void;
 };
 
@@ -28,13 +37,17 @@ const TARGET_SAMPLE_RATE = 16000;
 const MAX_BUFFERED_PCM_CHUNKS = 24;
 const PCM_CAPTURE_WORKLET_PATH = '/pcmCaptureWorklet.js';
 
-export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStreamingOptions) {
+export function useDeepgramStreaming({ enabled, onUtterance, sessionKey }: UseDeepgramStreamingOptions) {
   const [state, setState] = useState<VoiceScoringStatus>('idle');
   const [liveTranscript, setLiveTranscript] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [issue, setIssue] = useState<VoiceRuntimeIssue | null>(null);
   const stateRef = useRef<VoiceScoringStatus>('idle');
   const liveTranscriptRef = useRef('');
   const liveConfidenceRef = useRef(0);
+  const sessionKeyRef = useRef(sessionKey);
+  const activeAttemptRef = useRef<VoiceAttempt>({ id: 0, sessionKey });
+  const tokenAbortControllerRef = useRef<AbortController | null>(null);
 
   const connectionRef = useRef<DeepgramLiveConnection | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -100,6 +113,36 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     }
   }, []);
 
+  const abortTokenRequest = useCallback(() => {
+    tokenAbortControllerRef.current?.abort();
+    tokenAbortControllerRef.current = null;
+  }, []);
+
+  const isAttemptActive = useCallback((attempt: VoiceAttempt) => (
+    isVoiceAttemptCurrent(activeAttemptRef.current, attempt)
+  ), []);
+
+  const logStaleAttempt = useCallback((attempt: VoiceAttempt, step: string) => {
+    logVoiceDebug('stale voice attempt ignored', {
+      step,
+      attemptId: attempt.id,
+      sessionKey: attempt.sessionKey,
+      activeAttemptId: activeAttemptRef.current.id,
+      activeSessionKey: activeAttemptRef.current.sessionKey,
+    });
+  }, []);
+
+  const invalidateActiveAttempt = useCallback((reason: string) => {
+    abortTokenRequest();
+    activeAttemptRef.current = createNextVoiceAttempt(activeAttemptRef.current, sessionKeyRef.current);
+    logVoiceDebug('voice attempt invalidated', {
+      reason,
+      attemptId: activeAttemptRef.current.id,
+      sessionKey: activeAttemptRef.current.sessionKey,
+    });
+    return activeAttemptRef.current;
+  }, [abortTokenRequest]);
+
   const cleanupAudio = useCallback((options?: { closeContext?: boolean }) => {
     cleanupAudioResources({
       mediaStreamRef,
@@ -141,29 +184,46 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     );
   }, []);
 
-  const handleRuntimeFailure = useCallback((message: string) => {
+  const handleRuntimeFailure = useCallback((message: string, nextIssue: VoiceRuntimeIssue, attempt?: VoiceAttempt) => {
+    if (attempt && !isAttemptActive(attempt)) {
+      logStaleAttempt(attempt, 'runtime-failure');
+      return;
+    }
+
     logVoiceError('runtime failure', {
       message,
+      issue: nextIssue,
       state: stateRef.current,
     });
+    invalidateActiveAttempt('runtime-failure');
     clearListeningTimeout();
+    abortTokenRequest();
     setError(message);
+    setIssue(nextIssue);
     setState('error');
     clearUtteranceBuffer();
     cleanupAudio();
     cleanupSocket();
-  }, [clearListeningTimeout, clearUtteranceBuffer, cleanupAudio, cleanupSocket]);
+  }, [abortTokenRequest, cleanupAudio, cleanupSocket, clearListeningTimeout, clearUtteranceBuffer, invalidateActiveAttempt, isAttemptActive, logStaleAttempt]);
 
   const reset = useCallback(() => {
+    invalidateActiveAttempt('reset');
     clearListeningTimeout();
+    abortTokenRequest();
     cleanupAudio();
     cleanupSocket();
     clearUtteranceBuffer();
     setError(null);
+    setIssue(null);
     setState('idle');
-  }, [clearListeningTimeout, cleanupAudio, cleanupSocket, clearUtteranceBuffer]);
+  }, [abortTokenRequest, cleanupAudio, cleanupSocket, clearListeningTimeout, clearUtteranceBuffer, invalidateActiveAttempt]);
 
-  const emitUtterance = useCallback((trigger: DeepgramUtteranceTrigger) => {
+  const emitUtterance = useCallback((trigger: DeepgramUtteranceTrigger, attempt: VoiceAttempt) => {
+    if (!isAttemptActive(attempt)) {
+      logStaleAttempt(attempt, 'emit-utterance');
+      return;
+    }
+
     if (utteranceClosedRef.current) {
       return;
     }
@@ -186,12 +246,21 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       setLiveTranscript('');
       setState('processing');
       window.setTimeout(() => {
+        if (!isAttemptActive(attempt)) {
+          logStaleAttempt(attempt, 'emit-utterance-post-process');
+          return;
+        }
+
         setState((current) => (current === 'processing' ? 'listening' : current));
       }, 0);
     } catch {
-      handleRuntimeFailure('Impossible de traiter la transcription vocale.');
+      handleRuntimeFailure(
+        buildVoiceRuntimeIssueMessage('transcript'),
+        'transcript',
+        attempt,
+      );
     }
-  }, [handleRuntimeFailure, onUtterance]);
+  }, [handleRuntimeFailure, isAttemptActive, logStaleAttempt, onUtterance]);
 
   const stop = useCallback(() => {
     clearListeningTimeout();
@@ -206,7 +275,7 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     reset();
   }, [clearListeningTimeout, reset]);
 
-  const ensureAudioCaptureReady = useCallback(async (mediaStream: MediaStream, timings: StartTimings) => {
+  const ensureAudioCaptureReady = useCallback(async (mediaStream: MediaStream, timings: StartTimings, attempt: VoiceAttempt) => {
     await ensureAudioCaptureGraphReady({
       refs: {
         mediaStreamRef,
@@ -218,14 +287,48 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
         bufferedPcmChunksRef,
       },
       mediaStream,
-      onAudioChunk: sendOrBufferAudioChunk,
-      onRuntimeFailure: () => handleRuntimeFailure('Impossible de streamer l audio micro.'),
-      onReady: () => setState('listening'),
+      onAudioChunk: (pcm) => {
+        if (!isAttemptActive(attempt)) {
+          logStaleAttempt(attempt, 'audio-chunk');
+          return;
+        }
+
+        sendOrBufferAudioChunk(pcm);
+      },
+      onRuntimeFailure: () => handleRuntimeFailure(
+        buildVoiceRuntimeIssueMessage('audio'),
+        'audio',
+        attempt,
+      ),
+      onReady: () => {
+        if (!isAttemptActive(attempt)) {
+          logStaleAttempt(attempt, 'audio-ready');
+          return;
+        }
+
+        setState('listening');
+      },
       pcmCaptureWorkletPath: PCM_CAPTURE_WORKLET_PATH,
       targetSampleRate: TARGET_SAMPLE_RATE,
       logTiming: timings.log,
     });
-  }, [cleanupAudio, handleRuntimeFailure, sendOrBufferAudioChunk]);
+  }, [handleRuntimeFailure, isAttemptActive, logStaleAttempt, sendOrBufferAudioChunk]);
+
+  useEffect(() => {
+    if (sessionKeyRef.current === sessionKey) {
+      return;
+    }
+
+    sessionKeyRef.current = sessionKey;
+    invalidateActiveAttempt('session-key-changed');
+    clearListeningTimeout();
+    cleanupAudio();
+    cleanupSocket();
+    clearUtteranceBuffer();
+    setError(null);
+    setIssue(null);
+    setState('idle');
+  }, [cleanupAudio, cleanupSocket, clearListeningTimeout, clearUtteranceBuffer, invalidateActiveAttempt, sessionKey]);
 
   const start = useCallback(async () => {
     const timings = createStartTimings();
@@ -234,7 +337,7 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       state: stateRef.current,
     });
 
-    if (!enabled || state === 'listening') {
+    if (!enabled || stateRef.current === 'listening' || stateRef.current === 'processing') {
       logVoiceDebug('start ignored', {
         enabled,
         state: stateRef.current,
@@ -242,16 +345,26 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       return;
     }
 
+    const attempt = invalidateActiveAttempt('start-requested');
     clearUtteranceBuffer();
     setError(null);
+    setIssue(null);
     setState('processing');
 
     try {
       logVoiceDebug('requesting token and microphone');
-      const tokenPromise = fetchDeepgramAccessToken().then((token) => {
-        timings.log('token-ready');
-        return token;
-      });
+      const tokenAbortController = new AbortController();
+      tokenAbortControllerRef.current = tokenAbortController;
+      const tokenPromise = fetchDeepgramAccessToken(tokenAbortController.signal)
+        .then((token) => {
+          timings.log('token-ready');
+          return token;
+        })
+        .finally(() => {
+          if (tokenAbortControllerRef.current === tokenAbortController) {
+            tokenAbortControllerRef.current = null;
+          }
+        });
 
       const mediaStreamPromise = navigator.mediaDevices.getUserMedia({
           audio: {
@@ -268,8 +381,20 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
       });
 
       const mediaStream = await mediaStreamPromise;
-      const audioSetupPromise = ensureAudioCaptureReady(mediaStream, timings);
+      if (!isAttemptActive(attempt)) {
+        logStaleAttempt(attempt, 'media-stream-ready');
+        mediaStream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
+      const audioSetupPromise = ensureAudioCaptureReady(mediaStream, timings, attempt);
       const { accessToken } = await tokenPromise;
+
+      if (!isAttemptActive(attempt)) {
+        logStaleAttempt(attempt, 'token-ready');
+        cleanupAudio();
+        return;
+      }
 
       logVoiceDebug('token and microphone ready', {
         hasAccessToken: Boolean(accessToken),
@@ -280,12 +405,22 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
         accessToken,
         {
           onOpen: () => {
+            if (!isAttemptActive(attempt)) {
+              logStaleAttempt(attempt, 'websocket-open');
+              return;
+            }
+
             logVoiceDebug('websocket open');
             socketReadyRef.current = true;
             timings.log('websocket-open');
             flushBufferedAudio();
           },
           onMessage: (payload) => {
+            if (!isAttemptActive(attempt)) {
+              logStaleAttempt(attempt, 'websocket-message');
+              return;
+            }
+
             try {
               logVoiceDebug('websocket message', {
                 type: payload.type,
@@ -300,7 +435,7 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
               }
 
               if (payload.type === 'UtteranceEnd') {
-                emitUtterance('utterance_end');
+                emitUtterance('utterance_end', attempt);
                 return;
               }
 
@@ -308,7 +443,11 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
                 logVoiceError('deepgram error payload', {
                   error: payload.error || 'Unknown Deepgram error',
                 });
-                handleRuntimeFailure(payload.error || 'Erreur Deepgram.');
+                handleRuntimeFailure(
+                  payload.error || buildVoiceRuntimeIssueMessage('connection'),
+                  'connection',
+                  attempt,
+                );
                 return;
               }
 
@@ -336,24 +475,41 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
               }
 
               if (payload.speech_final) {
-                emitUtterance('speech_final');
+                emitUtterance('speech_final', attempt);
               }
             } catch (error) {
               logVoiceError('invalid websocket message', {
                 message: describeCaughtError(error),
                 type: payload.type,
               });
-              handleRuntimeFailure('Message vocal invalide ou illisible.');
+              handleRuntimeFailure(
+                buildVoiceRuntimeIssueMessage('transcript'),
+                'transcript',
+                attempt,
+              );
             }
           },
           onError: (caughtError) => {
+            if (!isAttemptActive(attempt)) {
+              logStaleAttempt(attempt, 'websocket-error');
+              return;
+            }
+
             logVoiceError('websocket error event', {
               message: describeCaughtError(caughtError),
             });
-            setError('Connexion vocale indisponible.');
-            setState('error');
+            handleRuntimeFailure(
+              buildVoiceRuntimeIssueMessage('connection'),
+              'connection',
+              attempt,
+            );
           },
           onClose: () => {
+            if (!isAttemptActive(attempt)) {
+              logStaleAttempt(attempt, 'websocket-close');
+              return;
+            }
+
             logVoiceDebug('websocket close', {
               previousState: stateRef.current,
             });
@@ -364,10 +520,23 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
           },
         },
       );
+
+      if (!isAttemptActive(attempt)) {
+        logStaleAttempt(attempt, 'websocket-connected');
+        connection.close();
+        cleanupAudio();
+        return;
+      }
+
       timings.log('websocket-client-created');
 
       clearListeningTimeout();
       listeningTimeoutRef.current = window.setTimeout(() => {
+        if (!isAttemptActive(attempt)) {
+          logStaleAttempt(attempt, 'listening-timeout');
+          return;
+        }
+
         logVoiceDebug('listening timeout reached', {
           timeoutMs: VOICE_SCORING_TIMEOUT_MS,
           finalChunks: finalChunksRef.current.length,
@@ -375,8 +544,10 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
         });
 
         if (finalChunksRef.current.length > 0 || liveTranscriptRef.current.trim()) {
-          emitUtterance('utterance_end');
+          emitUtterance('utterance_end', attempt);
         }
+
+        invalidateActiveAttempt('listening-timeout');
 
         try {
           if (connectionRef.current?.readyState === WebSocket.OPEN) {
@@ -386,21 +557,44 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
           // ignore close stream failures during timeout shutdown
         }
 
+        abortTokenRequest();
         cleanupAudio();
         cleanupSocket();
-        setState((current) => (current === 'error' ? current : 'idle'));
+        setError(buildVoiceRuntimeIssueMessage('timeout'));
+        setIssue('timeout');
+        setState('error');
       }, VOICE_SCORING_TIMEOUT_MS);
 
       await audioSetupPromise;
+      if (!isAttemptActive(attempt)) {
+        logStaleAttempt(attempt, 'audio-setup-complete');
+        return;
+      }
+
       timings.log('start-ready');
     } catch (caughtError) {
+      if (!isAttemptActive(attempt)) {
+        logStaleAttempt(attempt, 'start-catch');
+        return;
+      }
+
+      if (caughtError instanceof DOMException && caughtError.name === 'AbortError') {
+        logVoiceDebug('voice start aborted', {
+          attemptId: attempt.id,
+          sessionKey: attempt.sessionKey,
+        });
+        return;
+      }
+
       logVoiceError('start failed', {
         message: describeCaughtError(caughtError),
       });
-      const message = caughtError instanceof Error ? caughtError.message : 'Impossible de lancer l ecoute.';
-      handleRuntimeFailure(message);
+      const nextIssue = resolveVoiceStartFailureCause(caughtError);
+      const fallbackMessage = caughtError instanceof Error ? caughtError.message : buildVoiceRuntimeIssueMessage(nextIssue);
+      handleRuntimeFailure(fallbackMessage, nextIssue, attempt);
     }
   }, [
+    abortTokenRequest,
     clearListeningTimeout,
     clearUtteranceBuffer,
     emitUtterance,
@@ -408,7 +602,9 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     ensureAudioCaptureReady,
     flushBufferedAudio,
     handleRuntimeFailure,
-    state,
+    invalidateActiveAttempt,
+    isAttemptActive,
+    logStaleAttempt,
     cleanupAudio,
     cleanupSocket,
   ]);
@@ -419,13 +615,15 @@ export function useDeepgramStreaming({ enabled, onUtterance }: UseDeepgramStream
     }
 
     return () => {
+      abortTokenRequest();
       cleanupAudio({ closeContext: true });
       cleanupSocket();
     };
-  }, [cleanupAudio, cleanupSocket, enabled, reset]);
+  }, [abortTokenRequest, cleanupAudio, cleanupSocket, enabled, reset]);
 
   return {
     error,
+    issue,
     isListening: state === 'listening',
     liveTranscript,
     reset,

--- a/src/features/x01/voice/voiceProposalModel.ts
+++ b/src/features/x01/voice/voiceProposalModel.ts
@@ -1,0 +1,71 @@
+import { parseDartsSpeechTranscript } from './dartsSpeechParser';
+import type {
+  DeepgramUtterance,
+  DartsSpeechParseResult,
+  ParseDartsSpeechContext,
+  VoiceScoreProposalState,
+} from './dartsSpeechTypes';
+
+type BuildVoiceScoreProposalInput = DeepgramUtterance & {
+  context: ParseDartsSpeechContext;
+};
+
+export function buildVoiceScoreProposal({
+  confidence,
+  context,
+  transcript,
+  trigger,
+}: BuildVoiceScoreProposalInput): VoiceScoreProposalState {
+  const parsedResult = parseDartsSpeechTranscript(transcript, context);
+  const guidance = buildVoiceProposalGuidance(parsedResult, context);
+  const result = guidance && guidance !== parsedResult.reason
+    ? { ...parsedResult, reason: guidance }
+    : parsedResult;
+
+  return {
+    guidance,
+    prefillScore: shouldPrefillVoiceProposalScore(result) ? String(result.score) : null,
+    result,
+    transcript,
+    trigger,
+  };
+}
+
+export function shouldPrefillVoiceProposalScore(result: DartsSpeechParseResult): boolean {
+  if (result.status === 'invalid' || result.score === null) {
+    return false;
+  }
+
+  if (result.intent === 'turn_score' || result.intent === 'remaining_score') {
+    return true;
+  }
+
+  return result.mode === 'darts' && result.status === 'valid' && result.coverage === 'full_turn';
+}
+
+export function buildVoiceProposalGuidance(
+  result: DartsSpeechParseResult,
+  context: ParseDartsSpeechContext,
+): string | null {
+  if (result.status === 'invalid') {
+    return result.reason;
+  }
+
+  if (result.mode === 'darts' && result.coverage === 'partial_turn') {
+    return 'Annonce partielle reconnue, confirmation explicite requise.';
+  }
+
+  if (result.mode === 'darts' && result.requiresConfirmation) {
+    return 'Sequence de flechettes reconnue, confirmation explicite requise.';
+  }
+
+  if (
+    result.intent === 'remaining_score'
+    && result.remainingScore !== null
+    && (context.startingScoreBeforeTurn ?? context.currentRemainingScore ?? 0) <= 170
+  ) {
+    return result.reason ?? 'Annonce de checkout reconnue, verification explicite recommandee.';
+  }
+
+  return result.reason;
+}

--- a/src/features/x01/voice/voiceSessionModel.ts
+++ b/src/features/x01/voice/voiceSessionModel.ts
@@ -1,0 +1,80 @@
+import type { VoiceRuntimeIssue, VoiceScoringStatus } from './dartsSpeechTypes';
+
+export type VoiceAttempt = {
+  id: number;
+  sessionKey: string;
+};
+
+export function createNextVoiceAttempt(currentAttempt: VoiceAttempt, sessionKey: string): VoiceAttempt {
+  return {
+    id: currentAttempt.id + 1,
+    sessionKey,
+  };
+}
+
+export function isVoiceAttemptCurrent(activeAttempt: VoiceAttempt, candidateAttempt: VoiceAttempt): boolean {
+  return activeAttempt.id === candidateAttempt.id && activeAttempt.sessionKey === candidateAttempt.sessionKey;
+}
+
+export function resolveVoiceStartFailureCause(error: unknown): VoiceRuntimeIssue {
+  if (error instanceof DOMException) {
+    if (error.name === 'AbortError') {
+      return 'connection';
+    }
+
+    if (['NotAllowedError', 'NotFoundError', 'NotReadableError', 'SecurityError'].includes(error.name)) {
+      return 'microphone';
+    }
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+
+    if (message.includes('token')) {
+      return 'token';
+    }
+
+    if (message.includes('audio') || message.includes('worklet')) {
+      return 'audio';
+    }
+
+    if (message.includes('micro')) {
+      return 'microphone';
+    }
+  }
+
+  return 'connection';
+}
+
+export function buildVoiceRuntimeIssueMessage(issue: VoiceRuntimeIssue): string {
+  switch (issue) {
+    case 'audio':
+      return 'Capture audio indisponible.';
+    case 'connection':
+      return 'Connexion vocale indisponible.';
+    case 'microphone':
+      return 'Micro indisponible ou refuse.';
+    case 'timeout':
+      return 'Aucune annonce detectee, repasse en saisie manuelle ou relance l ecoute.';
+    case 'token':
+      return 'Jeton vocal indisponible.';
+    case 'transcript':
+      return 'Transcription vocale trop ambigue.';
+  }
+}
+
+export function buildVoiceStateLabel(state: VoiceScoringStatus, issue: VoiceRuntimeIssue | null): string {
+  if (state === 'processing') {
+    return issue ? `Traitement vocal - ${buildVoiceRuntimeIssueMessage(issue)}` : 'Traitement vocal';
+  }
+
+  if (state === 'listening') {
+    return 'Ecoute en cours';
+  }
+
+  if (state === 'error' && issue) {
+    return buildVoiceRuntimeIssueMessage(issue);
+  }
+
+  return 'Scoring vocal';
+}

--- a/src/features/x01/voice/voiceStreamingLogger.ts
+++ b/src/features/x01/voice/voiceStreamingLogger.ts
@@ -1,0 +1,13 @@
+const VOICE_DEBUG_PREFIX = '[voice-scoring]';
+
+export const logVoiceDebug = (step: string, extra?: Record<string, unknown>) => {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  console.debug(`${VOICE_DEBUG_PREFIX} ${step}`, extra);
+};
+
+export const logVoiceError = (step: string, extra?: Record<string, unknown>) => {
+  console.error(`${VOICE_DEBUG_PREFIX} ${step}`, extra);
+};

--- a/src/features/x01/voice/voiceStreamingModel.ts
+++ b/src/features/x01/voice/voiceStreamingModel.ts
@@ -1,0 +1,52 @@
+import type { DeepgramUtterance } from './dartsSpeechTypes';
+
+export type FinalChunk = {
+  transcript: string;
+  confidence: number;
+};
+
+export const appendBufferedPcmChunk = (
+  bufferedChunks: Int16Array[],
+  nextChunk: Int16Array,
+  maxChunks: number,
+): Int16Array[] => {
+  const nextBufferedChunks = bufferedChunks.length >= maxChunks
+    ? bufferedChunks.slice(1)
+    : bufferedChunks.slice();
+
+  nextBufferedChunks.push(nextChunk.slice());
+  return nextBufferedChunks;
+};
+
+export const buildDeepgramUtterance = (
+  finalChunks: FinalChunk[],
+  liveTranscript: string,
+  liveConfidence: number,
+  trigger: DeepgramUtterance['trigger'],
+): DeepgramUtterance | null => {
+  const finalTranscript = finalChunks
+    .map((chunk) => chunk.transcript.trim())
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  const transcript = finalTranscript || liveTranscript.trim();
+  if (!transcript) {
+    return null;
+  }
+
+  const totalConfidence = finalChunks.reduce((sum, chunk) => sum + chunk.confidence, 0);
+  const confidence = finalChunks.length > 0
+    ? totalConfidence / finalChunks.length
+    : liveConfidence;
+
+  return {
+    transcript,
+    confidence,
+    trigger,
+  };
+};
+
+export const describeCaughtError = (error: unknown) => (
+  error instanceof Error ? error.message : 'Unknown error'
+);

--- a/src/infrastructure/observability/vercelAnalyticsAdapter.ts
+++ b/src/infrastructure/observability/vercelAnalyticsAdapter.ts
@@ -1,8 +1,18 @@
-import { track } from '@vercel/analytics';
+import { pageview, track } from '@vercel/analytics';
 import { AnalyticsPort } from '../../application/observability/analyticsPort';
-import { AnalyticsPayload, FeatureFlags } from '../../domain/observability/analyticsDomain';
+import {
+  AnalyticsPageView,
+  AnalyticsPayload,
+  FeatureFlags,
+} from '../../domain/observability/analyticsDomain';
 
 const DATA_FLAGS_SELECTOR = 'script[data-flag-values]';
+
+const serializeFlagsForScriptTag = (flags: FeatureFlags) =>
+  JSON.stringify(flags)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 
 const setFeatureFlagsInDOM = (flags: FeatureFlags) => {
   if (typeof document === 'undefined') return;
@@ -10,7 +20,7 @@ const setFeatureFlagsInDOM = (flags: FeatureFlags) => {
   const script = existing instanceof HTMLScriptElement ? existing : document.createElement('script');
   script.type = 'application/json';
   script.setAttribute('data-flag-values', '');
-  script.textContent = JSON.stringify(flags);
+  script.textContent = serializeFlagsForScriptTag(flags);
   if (!existing) {
     document.head.appendChild(script);
   }
@@ -20,7 +30,12 @@ const trackEvent = (eventName: string, payload: AnalyticsPayload, options?: { fl
   track(eventName, payload, options);
 };
 
+const trackPageView = ({ route, path }: AnalyticsPageView) => {
+  pageview({ route, path });
+};
+
 export const createVercelAnalyticsPort = (): AnalyticsPort => ({
   setFeatureFlagsInDOM,
   trackEvent,
+  trackPageView,
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,7 +3,6 @@ type PublicEnv = {
   VITE_APP_NAME: string;
   VITE_APP_VERSION: string;
   VITE_APP_URL: string;
-  VITE_TOURNAMENT_API_URL: string;
   VITE_APP_ACCESS_MODE: string;
   VITE_ENABLE_VOICE_SCORING: boolean;
   VITE_LOG_LEVEL: string;
@@ -34,7 +33,6 @@ export const env: PublicEnv = {
   VITE_APP_NAME: read("VITE_APP_NAME", "Bougnat Darts Counter"),
   VITE_APP_VERSION: read("VITE_APP_VERSION", "dev"),
   VITE_APP_URL: readPublic("VITE_APP_URL"),
-  VITE_TOURNAMENT_API_URL: read("VITE_TOURNAMENT_API_URL"),
   VITE_APP_ACCESS_MODE: read("VITE_APP_ACCESS_MODE", "local"),
   VITE_ENABLE_VOICE_SCORING: toBoolean(read("VITE_ENABLE_VOICE_SCORING"), false),
   VITE_LOG_LEVEL: read("VITE_LOG_LEVEL", "info"),

--- a/tests/e2e/gameplay-entry.smoke.spec.ts
+++ b/tests/e2e/gameplay-entry.smoke.spec.ts
@@ -35,8 +35,11 @@ test.describe('Bougnat Darts smoke gameplay entry', () => {
     await openSetup(page, 'Triathlon');
     await startConfiguredGame(page);
 
-    await expect(page.getByRole('heading', { name: /Tir a la bulle/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /D-Bull/i }).first()).toBeVisible();
-    await expect(page.getByRole('button', { name: /^Bull$/i }).first()).toBeVisible();
+    await expect(page.getByTestId('starting-player-overlay')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Qui commence \?/i })).toBeVisible();
+
+    await pickDefaultStarterIfNeeded(page);
+
+    await expect(page.getByText(/Objectif Actuel/i)).toBeVisible();
   });
 });

--- a/tests/unit/application/matchStats.test.ts
+++ b/tests/unit/application/matchStats.test.ts
@@ -24,6 +24,11 @@ const baseConfig: GameConfig = {
   initialStartingPlayerIndex: 0,
 };
 
+const buildConfig = (overrides: Partial<GameConfig> = {}): GameConfig => ({
+  ...baseConfig,
+  ...overrides,
+});
+
 describe('match stats', () => {
   it('estimates the minimum darts needed by checkout rule', () => {
     expect(getMinDartsForScore(50, 'Double')).toBe(1);
@@ -58,6 +63,54 @@ describe('match stats', () => {
       checkoutAttempts: 1,
       highestCheckout: 60,
       highestScore: 60,
+    });
+  });
+
+  it('does not count a placement turn from a checkout range as a checkout attempt', () => {
+    const match = createMatch(players, buildConfig({ startingScore: 64 }));
+    const ongoingMatch = submitTurn(match, 24, 3);
+
+    expect(calculateDetailedStats(ongoingMatch, 'p1')).toMatchObject({
+      checkoutRate: 0,
+      checkoutMade: 0,
+      checkoutAttempts: 0,
+      checkoutByDarts: {
+        one: { attempts: 0, made: 0 },
+        two: { attempts: 0, made: 0 },
+        three: { attempts: 0, made: 0 },
+      },
+    });
+  });
+
+  it('counts a bust from a checkout range as a failed checkout attempt', () => {
+    const match = createMatch(players, buildConfig({ startingScore: 40 }));
+    const ongoingMatch = submitTurn(match, 41, 3);
+
+    expect(calculateDetailedStats(ongoingMatch, 'p1')).toMatchObject({
+      checkoutRate: 0,
+      checkoutMade: 0,
+      checkoutAttempts: 1,
+      checkoutByDarts: {
+        one: { attempts: 0, made: 0 },
+        two: { attempts: 0, made: 0 },
+        three: { attempts: 1, made: 0 },
+      },
+    });
+  });
+
+  it('uses the actual darts thrown for checkout attempt buckets', () => {
+    const match = createMatch(players, buildConfig({ startingScore: 50 }));
+    const finishedMatch = submitTurn(match, 50, 2);
+
+    expect(calculateDetailedStats(finishedMatch, 'p1')).toMatchObject({
+      checkoutRate: 100,
+      checkoutMade: 1,
+      checkoutAttempts: 1,
+      checkoutByDarts: {
+        one: { attempts: 0, made: 0 },
+        two: { attempts: 1, made: 1 },
+        three: { attempts: 0, made: 0 },
+      },
     });
   });
 });

--- a/tests/unit/capitalGameModel.test.ts
+++ b/tests/unit/capitalGameModel.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { capitalGameReducer, createInitialCapitalGameState, isCapitalGameOver, sortCapitalResults } from '../../src/features/capital/capitalGameModel';
+import type { Player } from '../../types';
+
+const players: Player[] = [
+  { id: 'p1', name: 'Alice', teamId: 'p1' },
+  { id: 'p2', name: 'Bob', teamId: 'p2' },
+];
+
+describe('capitalGameModel', () => {
+  it('captures a snapshot before adding a dart and resolves the round', () => {
+    let state = createInitialCapitalGameState(players, 0);
+
+    state = capitalGameReducer(state, { type: 'add_dart', dart: { value: 20, multiplier: 1 } });
+
+    expect(state.history).toHaveLength(1);
+    expect(state.pendingResolution?.playerId).toBe('p1');
+
+    state = capitalGameReducer(state, { type: 'resolve_round' });
+
+    expect(state.states[0].score).toBe(20);
+    expect(state.states[0].targetIndex).toBe(1);
+    expect(state.currentPlayerIdx).toBe(1);
+  });
+
+  it('sorts results and detects game completion', () => {
+    const finished = [
+      { id: 'p1', name: 'Alice', score: 140, targetIndex: 17, history: [] },
+      { id: 'p2', name: 'Bob', score: 120, targetIndex: 17, history: [] },
+    ];
+
+    expect(isCapitalGameOver(finished)).toBe(true);
+    expect(sortCapitalResults(finished).map((entry) => entry.id)).toEqual(['p1', 'p2']);
+  });
+});

--- a/tests/unit/cricketGameModel.test.ts
+++ b/tests/unit/cricketGameModel.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  advanceCricketTurn,
+  appendAggregateCricketHit,
+  buildCricketCompetitors,
+  buildCricketHistorySnapshot,
+  buildCricketMatchSummary,
+  initAggregateCricketStats,
+} from '../../src/features/cricket/cricketGameModel';
+import type { CricketPlayerState, GameConfig, Player } from '../../types';
+
+const players: Player[] = [
+  { id: 'a1', name: 'Alice', teamId: 'team1' },
+  { id: 'a2', name: 'Ava', teamId: 'team1' },
+  { id: 'b1', name: 'Bob', teamId: 'team2' },
+  { id: 'b2', name: 'Ben', teamId: 'team2' },
+];
+
+const config: GameConfig = {
+  startingScore: 501,
+  checkIn: 'Open',
+  checkOut: 'Double',
+  matchMode: 'LEGS',
+  setsToWin: 1,
+  legsToWin: 1,
+  cricketRounds: 20,
+  isDoubles: true,
+};
+
+describe('cricketGameModel', () => {
+  it('builds team competitors and aggregate stats for doubles', () => {
+    const competitors = buildCricketCompetitors(players, true);
+    expect(competitors).toEqual([
+      { id: 'team1', name: 'Equipe 1', memberNames: ['Alice', 'Ava'] },
+      { id: 'team2', name: 'Equipe 2', memberNames: ['Bob', 'Ben'] },
+    ]);
+
+    const aggregateStats = initAggregateCricketStats(competitors);
+    expect(aggregateStats).toHaveLength(2);
+    expect(aggregateStats[0].id).toBe('team1');
+  });
+
+  it('appends aggregate hits and snapshots without mutating the input states', () => {
+    const [competitor] = buildCricketCompetitors(players, false);
+    const baseState = initAggregateCricketStats([competitor]);
+    const updated = appendAggregateCricketHit(baseState, competitor.id, 20, 3, 60, false);
+
+    expect(baseState[0].score).toBe(0);
+    expect(updated[0].score).toBe(60);
+    expect(updated[0].marks[20]).toBe(3);
+
+    const snapshot = buildCricketHistorySnapshot(updated, updated, 0, 1, players, null);
+    updated[0].history[0].pointsScored = 0;
+    expect(snapshot.states[0].history[0].pointsScored).toBe(60);
+  });
+
+  it('builds match summaries and advances turn state correctly', () => {
+    const competitors: CricketPlayerState[] = initAggregateCricketStats(buildCricketCompetitors(players, true));
+    const summary = buildCricketMatchSummary(
+      competitors,
+      'team1',
+      config,
+      { team1: ['Alice', 'Ava'], team2: ['Bob', 'Ben'] },
+      { team1: 1 },
+      {},
+      {},
+    );
+
+    expect(summary.winnerId).toBe('team1');
+    expect(summary.isDoubles).toBe(true);
+
+    expect(advanceCricketTurn(1, 4, 1)).toEqual({
+      nextTurnDartsThrown: 2,
+      shouldAdvanceThrower: false,
+      nextThrowerOffset: 0,
+    });
+    expect(advanceCricketTurn(2, 4, 1)).toEqual({
+      nextTurnDartsThrown: 0,
+      shouldAdvanceThrower: true,
+      nextThrowerOffset: 1,
+    });
+  });
+});

--- a/tests/unit/gameSetup/setupModel.test.ts
+++ b/tests/unit/gameSetup/setupModel.test.ts
@@ -131,11 +131,12 @@ describe('setup model', () => {
       team2Names: ['', ''],
       playAgainstBot: true,
       botLevel: 'PRO',
+      random: () => 0,
     });
 
     expect(players).toHaveLength(2);
     expect(players[0]).toMatchObject({ id: 'p1', name: 'Alice', teamId: 'p1' });
-    expect(players[1]).toMatchObject({ id: 'p2', name: 'Robot', teamId: 'p2', isBot: true, botLevel: 'PRO' });
+    expect(players[1]).toMatchObject({ id: 'p2', name: '[BOT] Alexis', teamId: 'p2', isBot: true, botLevel: 'PRO' });
   });
 
   it('limits Killer to six simple players and disables bots', () => {

--- a/tests/unit/gameSetup/setupViewModel.test.ts
+++ b/tests/unit/gameSetup/setupViewModel.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSetupSummaryEntries,
+  buildTeamStarterOptions,
+  canEnableBotOpponent,
+  getSetupPlayerCountOptions,
+  supportsDoublesMode,
+} from '../../../src/features/game-setup/setupViewModel';
+
+describe('setup view model', () => {
+  it('keeps the player count options aligned with game constraints', () => {
+    expect(getSetupPlayerCountOptions('X01')).toEqual([1, 2]);
+    expect(getSetupPlayerCountOptions('CRICKET')).toEqual([2, 3]);
+    expect(getSetupPlayerCountOptions('KILLER')).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('exposes doubles and bot capabilities by game type', () => {
+    expect(supportsDoublesMode('TRIATHLON')).toBe(true);
+    expect(supportsDoublesMode('GOTCHA')).toBe(false);
+    expect(canEnableBotOpponent('X01', false)).toBe(true);
+    expect(canEnableBotOpponent('X01', true)).toBe(false);
+    expect(canEnableBotOpponent('KILLER', false)).toBe(false);
+  });
+
+  it('builds starter labels without leaking fallback logic into the view', () => {
+    expect(buildTeamStarterOptions('team1', ['Alice', ''])).toEqual([
+      { id: 't1p1', label: 'Alice' },
+      { id: 't1p2', label: 'Joueur 2' },
+    ]);
+    expect(buildTeamStarterOptions('team2', ['', 'Dan'])).toEqual([
+      { id: 't2p1', label: 'Joueur 3' },
+      { id: 't2p2', label: 'Dan' },
+    ]);
+  });
+
+  it('builds summary rows for X01 and Triathlon without changing labels', () => {
+    expect(buildSetupSummaryEntries({
+      gameType: 'X01',
+      startingScore: 501,
+      matchMode: 'SETS',
+      legsToWin: 5,
+      setsToWin: 3,
+      cricketRounds: 20,
+      isDoubles: false,
+      playerCount: 2,
+      checkIn: 'Open',
+      checkOut: 'Double',
+    })).toEqual([
+      { label: 'Jeu', value: 'X01' },
+      { label: 'Score De Depart', value: 501 },
+      { label: 'Format', value: 'Sets' },
+      { label: 'Sets Pour Gagner', value: 3 },
+      { label: 'Manches Par Set', value: 5 },
+      { label: 'Ouverture / Fermeture', value: 'Open / Double' },
+      { label: 'Mode', value: 'Simple' },
+    ]);
+
+    expect(buildSetupSummaryEntries({
+      gameType: 'TRIATHLON',
+      startingScore: 501,
+      matchMode: 'LEGS',
+      legsToWin: 1,
+      setsToWin: 1,
+      cricketRounds: 20,
+      isDoubles: true,
+      playerCount: 2,
+      checkIn: 'Open',
+      checkOut: 'Double',
+    })).toEqual([
+      { label: 'Jeu', value: 'Triathlon' },
+      { label: 'Ordre Des Jeux', value: 'Capital / Cricket / 501' },
+      { label: 'Format', value: 'Doublettes' },
+    ]);
+  });
+});

--- a/tests/unit/observability/analyticsApplication.test.ts
+++ b/tests/unit/observability/analyticsApplication.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { ANALYTICS_EVENT } from '../../../src/domain/observability/analyticsDomain';
+import {
+  ANALYTICS_EVENT,
+  buildAnalyticsPageView,
+} from '../../../src/domain/observability/analyticsDomain';
 import { AnalyticsPort } from '../../../src/application/observability/analyticsPort';
-import { syncFeatureFlags, trackAnalyticsEvent, trackGameEvent } from '../../../src/application/observability/analyticsUseCases';
+import {
+  syncFeatureFlags,
+  trackAnalyticsEvent,
+  trackGameEvent,
+  trackPageView,
+} from '../../../src/application/observability/analyticsUseCases';
 
 describe('analytics application use-cases', () => {
   it('delegates feature-flag sync to the analytics port', () => {
     const setFeatureFlagsInDOM = vi.fn();
     const trackEvent = vi.fn();
-    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent };
+    const trackPageView = vi.fn();
+    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent, trackPageView };
 
     syncFeatureFlags(port, { 'game-x01': true, screen: 'SETUP' });
 
@@ -18,7 +27,8 @@ describe('analytics application use-cases', () => {
   it('tracks game event without overriding automatic flag attribution', () => {
     const setFeatureFlagsInDOM = vi.fn();
     const trackEvent = vi.fn();
-    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent };
+    const trackPageView = vi.fn();
+    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent, trackPageView };
 
     trackGameEvent(port, ANALYTICS_EVENT.GameFinished, 'CRICKET', {
       game_type: 'CRICKET',
@@ -34,7 +44,8 @@ describe('analytics application use-cases', () => {
   it('tracks generic analytics events without overriding flag attribution', () => {
     const setFeatureFlagsInDOM = vi.fn();
     const trackEvent = vi.fn();
-    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent };
+    const trackPageView = vi.fn();
+    const port: AnalyticsPort = { setFeatureFlagsInDOM, trackEvent, trackPageView };
 
     trackAnalyticsEvent(port, ANALYTICS_EVENT.ScreenView, {
       screen: 'SETUP',
@@ -46,5 +57,31 @@ describe('analytics application use-cases', () => {
       ANALYTICS_EVENT.ScreenView,
       { screen: 'SETUP', previous_screen: 'GAME_SELECTION', game_type: 'GOTCHA' },
     );
+  });
+
+  it('delegates SPA pageviews to the analytics port', () => {
+    const setFeatureFlagsInDOM = vi.fn();
+    const trackEvent = vi.fn();
+    const trackPageViewPort = vi.fn();
+    const port: AnalyticsPort = {
+      setFeatureFlagsInDOM,
+      trackEvent,
+      trackPageView: trackPageViewPort,
+    };
+
+    const pageView = buildAnalyticsPageView('TRIATHLON_GAME', 'TRIATHLON');
+    trackPageView(port, pageView);
+
+    expect(trackPageViewPort).toHaveBeenCalledWith({
+      route: '/app/triathlon/match',
+      path: '/app/triathlon/match',
+    });
+  });
+
+  it('builds setup pageviews from the selected game type', () => {
+    expect(buildAnalyticsPageView('SETUP', 'GOTCHA')).toEqual({
+      route: '/app/gotcha/setup',
+      path: '/app/gotcha/setup',
+    });
   });
 });

--- a/tests/unit/x01/botVictoryPreview.test.ts
+++ b/tests/unit/x01/botVictoryPreview.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMatch, submitTurn } from '../../../src/application/scoring/matchLifecycle';
+import { resolveBotVictoryPreview } from '../../../src/features/x01/scoring/botVictoryPreview';
+import type { GameConfig, Player } from '../../../types';
+
+const players: Player[] = [
+  { id: 'p1', name: 'Joueur 1', teamId: 'p1' },
+  { id: 'p2', name: 'Robot', teamId: 'p2', isBot: true, botLevel: 'CLUB' },
+];
+
+const config: GameConfig = {
+  startingScore: 40,
+  checkIn: 'Open',
+  checkOut: 'Double',
+  matchMode: 'LEGS',
+  setsToWin: 1,
+  legsToWin: 2,
+  isDoubles: false,
+  initialStartingPlayerIndex: 0,
+};
+
+describe('resolveBotVictoryPreview', () => {
+  it('returns a leg preview only when the bot just advanced the match to the next leg', () => {
+    const match = createMatch(players, config);
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotLegWin = submitTurn(afterHumanMiss, 40, 1);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterHumanMiss,
+      nextMatch: afterBotLegWin,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: false,
+    })).toEqual({
+      hasBotWonLeg: true,
+      hasBotWonMatch: false,
+      previewKind: 'leg',
+    });
+  });
+
+  it('does not retrigger the leg preview on later bot turns after an earlier bot leg win', () => {
+    const match = createMatch(players, config);
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotLegWin = submitTurn(afterHumanMiss, 40, 1);
+    const afterNextBotTurn = submitTurn(afterBotLegWin, 0, 3);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterBotLegWin,
+      nextMatch: afterNextBotTurn,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: false,
+    })).toEqual({
+      hasBotWonLeg: false,
+      hasBotWonMatch: false,
+      previewKind: null,
+    });
+  });
+
+  it('returns a match preview when the bot closes the match', () => {
+    const match = createMatch(players, { ...config, legsToWin: 1 });
+    const afterHumanMiss = submitTurn(match, 0, 3);
+    const afterBotMatchWin = submitTurn(afterHumanMiss, 40, 1);
+
+    expect(resolveBotVictoryPreview({
+      previousMatch: afterHumanMiss,
+      nextMatch: afterBotMatchWin,
+      currentPlayerTeamId: 'p2',
+      showWinnerScreen: true,
+    })).toEqual({
+      hasBotWonLeg: false,
+      hasBotWonMatch: true,
+      previewKind: 'match',
+    });
+  });
+});

--- a/tests/unit/x01/voiceProposalModel.test.ts
+++ b/tests/unit/x01/voiceProposalModel.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildVoiceProposalGuidance,
+  buildVoiceScoreProposal,
+  shouldPrefillVoiceProposalScore,
+} from '../../../src/features/x01/voice/voiceProposalModel';
+
+describe('voice proposal model', () => {
+  it('prefills simple total and remaining-score proposals', () => {
+    expect(buildVoiceScoreProposal({
+      confidence: 0.92,
+      context: {
+        currentRemainingScore: 301,
+        startingScoreBeforeTurn: 301,
+      },
+      transcript: '100',
+      trigger: 'speech_final',
+    }).prefillScore).toBe('100');
+
+    expect(buildVoiceScoreProposal({
+      confidence: 0.92,
+      context: {
+        currentRemainingScore: 72,
+        startingScoreBeforeTurn: 72,
+      },
+      transcript: 'reste 32',
+      trigger: 'utterance_end',
+    }).prefillScore).toBe('40');
+  });
+
+  it('does not prefill ambiguous darts sequences', () => {
+    const proposal = buildVoiceScoreProposal({
+      confidence: 0.84,
+      context: {
+        currentRemainingScore: 141,
+        dartsAlreadyThrown: 1,
+        startingScoreBeforeTurn: 141,
+      },
+      transcript: 'triple 20 5',
+      trigger: 'speech_final',
+    });
+
+    expect(proposal.result.status).toBe('ambiguous');
+    expect(proposal.prefillScore).toBeNull();
+    expect(proposal.guidance).toBe('Annonce partielle reconnue, confirmation explicite requise.');
+  });
+
+  it('marks checkout-style remaining announcements with business guidance', () => {
+    const proposal = buildVoiceScoreProposal({
+      confidence: 0.91,
+      context: {
+        currentRemainingScore: 72,
+        startingScoreBeforeTurn: 72,
+      },
+      transcript: 'reste 32',
+      trigger: 'speech_final',
+    });
+
+    expect(proposal.result.reason).toBe('Annonce de checkout reconnue, verification explicite recommandee.');
+  });
+
+  it('exposes prefill policy as a focused predicate', () => {
+    expect(shouldPrefillVoiceProposalScore({
+      confidence: 0.95,
+      confidenceTier: 'high',
+      consumedDarts: 3,
+      coverage: 'full_turn',
+      darts: [],
+      intent: 'turn_score',
+      mode: 'total',
+      normalizedTranscript: '100',
+      reason: null,
+      remainingScore: 201,
+      requiresConfirmation: false,
+      score: 100,
+      status: 'valid',
+      transcript: '100',
+    })).toBe(true);
+
+    expect(buildVoiceProposalGuidance({
+      confidence: 0.81,
+      confidenceTier: 'medium',
+      consumedDarts: 2,
+      coverage: 'partial_turn',
+      darts: [],
+      intent: 'darts_sequence',
+      mode: 'darts',
+      normalizedTranscript: '20 5',
+      reason: 'Scores de flechettes annonces a confirmer.',
+      remainingScore: 116,
+      requiresConfirmation: true,
+      score: 25,
+      status: 'ambiguous',
+      transcript: '20 5',
+    }, {
+      currentRemainingScore: 141,
+      dartsAlreadyThrown: 1,
+      startingScoreBeforeTurn: 141,
+    })).toBe('Annonce partielle reconnue, confirmation explicite requise.');
+  });
+});

--- a/tests/unit/x01/voiceSessionModel.test.ts
+++ b/tests/unit/x01/voiceSessionModel.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildVoiceRuntimeIssueMessage,
+  buildVoiceStateLabel,
+  createNextVoiceAttempt,
+  isVoiceAttemptCurrent,
+  resolveVoiceStartFailureCause,
+} from '../../../src/features/x01/voice/voiceSessionModel';
+
+describe('voice session model', () => {
+  it('increments attempts and invalidates stale sessions', () => {
+    const firstAttempt = { id: 1, sessionKey: 'match:1' };
+    const nextAttempt = createNextVoiceAttempt(firstAttempt, 'match:2');
+
+    expect(nextAttempt).toEqual({ id: 2, sessionKey: 'match:2' });
+    expect(isVoiceAttemptCurrent(nextAttempt, nextAttempt)).toBe(true);
+    expect(isVoiceAttemptCurrent(nextAttempt, firstAttempt)).toBe(false);
+  });
+
+  it('classifies microphone, token and audio failures', () => {
+    expect(resolveVoiceStartFailureCause(new DOMException('denied', 'NotAllowedError'))).toBe('microphone');
+    expect(resolveVoiceStartFailureCause(new Error('Voice token request failed (503)'))).toBe('token');
+    expect(resolveVoiceStartFailureCause(new Error('AudioWorklet non supporte'))).toBe('audio');
+  });
+
+  it('builds explicit issue messages and labels', () => {
+    expect(buildVoiceRuntimeIssueMessage('timeout')).toBe('Aucune annonce detectee, repasse en saisie manuelle ou relance l ecoute.');
+    expect(buildVoiceStateLabel('listening', null)).toBe('Ecoute en cours');
+    expect(buildVoiceStateLabel('error', 'connection')).toBe('Connexion vocale indisponible.');
+  });
+});

--- a/tests/unit/x01/voiceStreamingModel.test.ts
+++ b/tests/unit/x01/voiceStreamingModel.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendBufferedPcmChunk, buildDeepgramUtterance, describeCaughtError } from '../../../src/features/x01/voice/voiceStreamingModel';
+
+describe('voice streaming model', () => {
+  it('keeps only the latest buffered pcm chunks', () => {
+    const first = new Int16Array([1]);
+    const second = new Int16Array([2]);
+    const third = new Int16Array([3]);
+
+    const buffered = appendBufferedPcmChunk([first, second], third, 2);
+
+    expect(Array.from(buffered[0])).toEqual([2]);
+    expect(Array.from(buffered[1])).toEqual([3]);
+  });
+
+  it('builds utterances from final chunks first, then live transcript fallback', () => {
+    expect(buildDeepgramUtterance([
+      { transcript: 'triple 20', confidence: 0.9 },
+      { transcript: 'double 10', confidence: 0.7 },
+    ], 'ignored', 0.2, 'speech_final')).toEqual({
+      transcript: 'triple 20 double 10',
+      confidence: 0.8,
+      trigger: 'speech_final',
+    });
+
+    expect(buildDeepgramUtterance([], 'single 20', 0.55, 'utterance_end')).toEqual({
+      transcript: 'single 20',
+      confidence: 0.55,
+      trigger: 'utterance_end',
+    });
+
+    expect(buildDeepgramUtterance([], '   ', 0.55, 'utterance_end')).toBeNull();
+  });
+
+  it('normalizes unknown caught errors to a stable message', () => {
+    expect(describeCaughtError(new Error('boom'))).toBe('boom');
+    expect(describeCaughtError('opaque')).toBe('Unknown error');
+  });
+});

--- a/tests/unit/x01/x01BotDefinition.test.ts
+++ b/tests/unit/x01/x01BotDefinition.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRandomX01BotName,
+  formatX01BotAverageRange,
+  getX01BotLevelDefinition,
+} from '../../../src/domain/x01Bot/x01Bot';
+
+describe('x01 bot definitions', () => {
+  it('formats the pro level as more than 85 average', () => {
+    expect(formatX01BotAverageRange(getX01BotLevelDefinition('PRO'))).toBe('+ de 85 de moyenne');
+  });
+
+  it('builds a bot name with a mixed French first-name dictionary', () => {
+    expect(buildRandomX01BotName(() => 0)).toBe('[BOT] Alexis');
+    expect(buildRandomX01BotName(() => 0.999999)).toBe('[BOT] Zoe');
+  });
+});

--- a/utils/capitalLogic.ts
+++ b/utils/capitalLogic.ts
@@ -21,7 +21,7 @@ export const CAPITAL_TARGET_NAMES: Record<CapitalTarget, string> = {
   '14': 'Le 14',
   '21_OU_MOINS': '21 ou moins',
   '13': 'Le 13',
-  CENTRE: 'Bulle ou D-Bull',
+  CENTRE: 'D-Bulle (25) ou Bulle (50)',
 };
 
 const BOARD_ORDER = [20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5];

--- a/utils/triathlonScoring.ts
+++ b/utils/triathlonScoring.ts
@@ -1,35 +1,23 @@
 import { CapitalPlayerState, CricketMatchSummary, MatchState, Player } from '../types';
 import { calculateDetailedStats, calculateDetailedStatsForTeam } from '../src/application/scoring/matchStats';
+import {
+  createEmptyTriathlonEvent,
+  createTriathlonScorecard,
+  TRIATHLON_EVENT_LABELS,
+  TRIATHLON_SCORING_RULES,
+  type TriathlonBonusLine,
+  type TriathlonEventKey,
+  type TriathlonEventScore,
+  type TriathlonScorecard,
+} from '../src/domain/triathlon';
 import { CRICKET_TARGETS } from './cricketLogic';
 
-export type TriathlonEventKey = 'capital' | 'cricket' | 'x01';
-
-export interface TriathlonBonusLine {
-  label: string;
-  points: number;
-  detail: string;
-}
-
-export interface TriathlonEventScore {
-  key: TriathlonEventKey;
-  label: string;
-  basePoints: number;
-  bonusPoints: number;
-  totalPoints: number;
-  summary: string;
-  bonuses: TriathlonBonusLine[];
-}
-
-export interface TriathlonScorecard {
-  competitorId: string;
-  competitorName: string;
-  capital: TriathlonEventScore;
-  cricket: TriathlonEventScore;
-  x01: TriathlonEventScore;
-  totalBasePoints: number;
-  totalBonusPoints: number;
-  totalScore: number;
-}
+export type {
+  TriathlonBonusLine,
+  TriathlonEventKey,
+  TriathlonEventScore,
+  TriathlonScorecard,
+} from '../src/domain/triathlon';
 
 type TriathlonCompetitor = Pick<Player, 'id' | 'name' | 'teamId'>;
 
@@ -51,105 +39,6 @@ type CapitalMetric = {
   penalties: number;
 };
 
-type RankRule = {
-  rankPoints: number[];
-};
-
-type BonusRule = {
-  points: number;
-  label: string;
-  detail: (value: number) => string;
-};
-
-const TRIATHLON_SCORING_RULES = {
-  x01: {
-    winnerBasePoints: 20,
-    closeLossBasePoints: 14,
-    standardLossBasePoints: 10,
-    closeLossThresholds: {
-      dartsGap: 3,
-      averageGap: 6,
-    },
-    bonuses: {
-      highestCheckout: {
-        points: 4,
-        label: 'Checkout eleve',
-        detail: (value: number) => `${value}`,
-      } satisfies BonusRule,
-      bestAverage: {
-        points: 5,
-        label: 'Meilleure moyenne',
-        detail: (value: number) => value.toFixed(1),
-      } satisfies BonusRule,
-      fewestDarts: {
-        points: 5,
-        label: 'Moins de flechettes',
-        detail: (value: number) => `${value}`,
-      } satisfies BonusRule,
-    },
-  },
-  cricket: {
-    rank: {
-      rankPoints: [20, 14, 10, 6],
-    } satisfies RankRule,
-    bonuses: {
-      bestMpr: {
-        points: 5,
-        label: 'Meilleur MPR',
-        detail: (value: number) => value.toFixed(2),
-      } satisfies BonusRule,
-      bestScore: {
-        points: 4,
-        label: 'Difference de score',
-        detail: (value: number) => `${value} pts`,
-      } satisfies BonusRule,
-      mostClosedNumbers: {
-        points: 4,
-        label: 'Numeros fermes',
-        detail: (value: number) => `${value}`,
-      } satisfies BonusRule,
-    },
-  },
-  capital: {
-    rank: {
-      rankPoints: [20, 16, 12, 8],
-    } satisfies RankRule,
-    bonuses: {
-      bestScore: {
-        points: 5,
-        label: 'Score cumule',
-        detail: (value: number) => `${value} pts`,
-      } satisfies BonusRule,
-      regularity: {
-        points: 4,
-        label: 'Regularite',
-        detail: (value: number) => `${value} reussites`,
-      } satisfies BonusRule,
-      fewestPenalties: {
-        points: 4,
-        label: 'Peu de penalites',
-        detail: (value: number) => `${value}`,
-      } satisfies BonusRule,
-    },
-  },
-} as const;
-
-const EMPTY_EVENT = (key: TriathlonEventKey, label: string): TriathlonEventScore => ({
-  key,
-  label,
-  basePoints: 0,
-  bonusPoints: 0,
-  totalPoints: 0,
-  summary: 'Epreuve non jouee.',
-  bonuses: [],
-});
-
-const EVENT_LABELS: Record<TriathlonEventKey, string> = {
-  capital: 'Capital',
-  cricket: 'Cricket',
-  x01: '501',
-};
-
 const parseStatNumber = (value: string | number | null | undefined) => {
   if (typeof value === 'number') return value;
   if (!value) return 0;
@@ -162,16 +51,7 @@ const toMap = (competitors: TriathlonCompetitor[]) =>
   Object.fromEntries(
     competitors.map((competitor) => [
       competitor.id,
-      {
-        competitorId: competitor.id,
-        competitorName: competitor.name,
-        capital: EMPTY_EVENT('capital', EVENT_LABELS.capital),
-        cricket: EMPTY_EVENT('cricket', EVENT_LABELS.cricket),
-        x01: EMPTY_EVENT('x01', EVENT_LABELS.x01),
-        totalBasePoints: 0,
-        totalBonusPoints: 0,
-        totalScore: 0,
-      } satisfies TriathlonScorecard,
+      createTriathlonScorecard(competitor.id, competitor.name),
     ])
   ) as Record<string, TriathlonScorecard>;
 
@@ -276,7 +156,7 @@ const buildX01EventScores = (
     competitors.map((competitor) => [
       competitor.id,
       {
-        ...EMPTY_EVENT('x01', EVENT_LABELS.x01),
+        ...createEmptyTriathlonEvent('x01', TRIATHLON_EVENT_LABELS.x01),
       },
     ])
   ) as Record<string, TriathlonEventScore>;
@@ -371,7 +251,7 @@ const buildCricketEventScores = (summary: CricketMatchSummary, competitors: Tria
     competitors.map((competitor) => [
       competitor.id,
       {
-        ...EMPTY_EVENT('cricket', EVENT_LABELS.cricket),
+        ...createEmptyTriathlonEvent('cricket', TRIATHLON_EVENT_LABELS.cricket),
       },
     ])
   ) as Record<string, TriathlonEventScore>;
@@ -480,7 +360,7 @@ const buildCapitalEventScores = (
     competitors.map((competitor) => [
       competitor.id,
       {
-        ...EMPTY_EVENT('capital', EVENT_LABELS.capital),
+        ...createEmptyTriathlonEvent('capital', TRIATHLON_EVENT_LABELS.capital),
       },
     ])
   ) as Record<string, TriathlonEventScore>;

--- a/views/CapitalGameView.tsx
+++ b/views/CapitalGameView.tsx
@@ -6,6 +6,12 @@ import { CapitalKeypad } from '../components/game/CapitalKeypad';
 import { Button } from '../components/ui/Button';
 import { StartingPlayerOverlay } from '../components/game/StartingPlayerOverlay';
 import { formatDuration, getOrderedPlayersAndStarter } from '../src/application/scoring/matchLifecycle';
+import {
+  capitalGameReducer,
+  createInitialCapitalGameState,
+  isCapitalGameOver,
+  sortCapitalResults,
+} from '../src/features/capital/capitalGameModel';
 
 interface CapitalGameViewProps {
   players: Player[];
@@ -14,185 +20,6 @@ interface CapitalGameViewProps {
   onFinish: (results: CapitalPlayerState[]) => void;
   skipStartingPlayerPrompt?: boolean;
 }
-
-type CapitalHistorySnapshot = {
-  orderedPlayers: Player[];
-  states: CapitalPlayerState[];
-  currentPlayerIdx: number;
-  currentDarts: CapitalDart[];
-  pendingResolution: CapitalPendingResolution | null;
-};
-
-type CapitalPendingResolution = {
-  darts: CapitalDart[];
-  playerId: string;
-  target: typeof CAPITAL_TARGETS[number];
-};
-
-type CapitalGameState = {
-  orderedPlayers: Player[];
-  states: CapitalPlayerState[];
-  currentPlayerIdx: number;
-  currentDarts: CapitalDart[];
-  history: CapitalHistorySnapshot[];
-  pendingResolution: CapitalPendingResolution | null;
-};
-
-type CapitalGameAction =
-  | { type: 'sync_rotation'; orderedPlayers: Player[]; currentPlayerIdx: number }
-  | { type: 'set_starter'; currentPlayerIdx: number }
-  | { type: 'add_dart'; dart: CapitalDart }
-  | { type: 'resolve_round' }
-  | { type: 'undo' };
-
-const cloneCapitalDarts = (darts: CapitalDart[]) => darts.map((dart) => ({ ...dart }));
-
-const cloneCapitalHistory = (history: CapitalPlayerState['history']) => history.map((entry) => ({
-  ...entry,
-  darts: cloneCapitalDarts(entry.darts),
-}));
-
-const cloneCapitalPlayerStates = (states: CapitalPlayerState[]) => states.map((state) => ({
-  ...state,
-  history: cloneCapitalHistory(state.history),
-}));
-
-const cloneCapitalOrderedPlayers = (players: Player[]) => players.map((player) => ({ ...player }));
-
-const cloneCapitalSnapshot = (state: CapitalGameState): CapitalHistorySnapshot => ({
-  orderedPlayers: cloneCapitalOrderedPlayers(state.orderedPlayers),
-  states: cloneCapitalPlayerStates(state.states),
-  currentPlayerIdx: state.currentPlayerIdx,
-  currentDarts: cloneCapitalDarts(state.currentDarts),
-  pendingResolution: state.pendingResolution
-    ? {
-        ...state.pendingResolution,
-        darts: cloneCapitalDarts(state.pendingResolution.darts),
-      }
-    : null,
-});
-
-const createCapitalPlayerStates = (players: Player[]): CapitalPlayerState[] =>
-  players.map((player) => ({
-    id: player.id,
-    name: player.name,
-    score: 0,
-    targetIndex: 0,
-    history: [],
-  }));
-
-const createInitialCapitalGameState = (orderedPlayers: Player[], currentPlayerIdx: number): CapitalGameState => ({
-  orderedPlayers: cloneCapitalOrderedPlayers(orderedPlayers),
-  states: createCapitalPlayerStates(orderedPlayers),
-  currentPlayerIdx,
-  currentDarts: [],
-  history: [],
-  pendingResolution: null,
-});
-
-const capitalGameReducer = (state: CapitalGameState, action: CapitalGameAction): CapitalGameState => {
-  switch (action.type) {
-    case 'sync_rotation':
-      return {
-        ...state,
-        orderedPlayers: cloneCapitalOrderedPlayers(action.orderedPlayers),
-        currentPlayerIdx: action.currentPlayerIdx,
-      };
-    case 'set_starter':
-      return {
-        ...state,
-        currentPlayerIdx: action.currentPlayerIdx,
-      };
-    case 'add_dart': {
-      if (state.pendingResolution || state.currentDarts.length >= 3) {
-        return state;
-      }
-
-      const currentPlayerId = state.orderedPlayers[state.currentPlayerIdx]?.id ?? state.states[0]?.id;
-      const currentPlayer = state.states.find((entry) => entry.id === currentPlayerId);
-      if (!currentPlayer) {
-        return state;
-      }
-
-      const currentTarget = currentPlayer.targetIndex < CAPITAL_TARGETS.length
-        ? CAPITAL_TARGETS[currentPlayer.targetIndex]
-        : 'CAPITAL';
-      const nextDarts = [...state.currentDarts, { ...action.dart }];
-      const shouldResolve = shouldResolveCapitalRound(currentTarget, nextDarts);
-
-      return {
-        ...state,
-        currentDarts: nextDarts,
-        history: [...state.history, cloneCapitalSnapshot(state)],
-        pendingResolution: shouldResolve
-          ? {
-              darts: cloneCapitalDarts(nextDarts),
-              playerId: currentPlayer.id,
-              target: currentTarget,
-            }
-          : null,
-      };
-    }
-    case 'resolve_round': {
-      if (!state.pendingResolution) {
-        return state;
-      }
-
-      const { playerId, darts, target } = state.pendingResolution;
-      const playerIndex = state.states.findIndex((entry) => entry.id === playerId);
-      if (playerIndex < 0) {
-        return {
-          ...state,
-          pendingResolution: null,
-          currentDarts: [],
-        };
-      }
-
-      const nextStates = cloneCapitalPlayerStates(state.states);
-      const playerState = nextStates[playerIndex];
-      const { newScore, pointsScored, isSuccess } = evaluateCapitalRound(target, darts, playerState.score);
-
-      playerState.history.push({
-        target,
-        darts: cloneCapitalDarts(darts),
-        pointsScored,
-        isSuccess,
-      });
-      playerState.score = newScore;
-      playerState.targetIndex += 1;
-
-      return {
-        ...state,
-        states: nextStates,
-        currentPlayerIdx: (state.currentPlayerIdx + 1) % state.orderedPlayers.length,
-        currentDarts: [],
-        pendingResolution: null,
-      };
-    }
-    case 'undo': {
-      if (state.history.length === 0) {
-        return state;
-      }
-
-      const previousState = state.history[state.history.length - 1];
-      return {
-        orderedPlayers: cloneCapitalOrderedPlayers(previousState.orderedPlayers),
-        states: cloneCapitalPlayerStates(previousState.states),
-        currentPlayerIdx: previousState.currentPlayerIdx,
-        currentDarts: cloneCapitalDarts(previousState.currentDarts),
-        history: state.history.slice(0, -1),
-        pendingResolution: previousState.pendingResolution
-          ? {
-              ...previousState.pendingResolution,
-              darts: cloneCapitalDarts(previousState.pendingResolution.darts),
-            }
-          : null,
-      };
-    }
-    default:
-      return state;
-  }
-};
 
 export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, config, onExit, onFinish, skipStartingPlayerPrompt = false }) => {
   const initialRotation = useMemo(() => getOrderedPlayersAndStarter(players, config), [players, config]);
@@ -214,7 +41,7 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, confi
   const currentTarget = currentPlayer?.targetIndex < CAPITAL_TARGETS.length ? CAPITAL_TARGETS[currentPlayer.targetIndex] : 'CAPITAL';
   const currentChallengeNumber = Math.min((currentPlayer?.targetIndex ?? 0) + 1, CAPITAL_TARGETS.length);
   const currentChallengeProgress = Math.min(((currentChallengeNumber - 1) / CAPITAL_TARGETS.length) * 100, 100);
-  const isGameOver = states.every(s => s.targetIndex >= CAPITAL_TARGETS.length);
+  const isGameOver = isCapitalGameOver(states);
   const starterOptions = orderedPlayers.map((player, index) => ({ id: String(index), label: player.name }));
 
   useEffect(() => {
@@ -287,7 +114,7 @@ export const CapitalGameView: React.FC<CapitalGameViewProps> = ({ players, confi
   };
 
   if (isGameOver) {
-    const sortedPlayers = [...states].sort((a, b) => b.score - a.score);
+    const sortedPlayers = sortCapitalResults(states);
     const winner = sortedPlayers[0];
     return (
       <div className="flex h-[100dvh] flex-col items-center justify-center bg-black p-4 text-white animate-in fade-in duration-500 sm:p-6">

--- a/views/CricketGameView.tsx
+++ b/views/CricketGameView.tsx
@@ -16,6 +16,15 @@ import { Button } from '../components/ui/Button';
 import { CricketStatsModal } from '../components/stats/CricketStatsModal';
 import { StartingPlayerOverlay } from '../components/game/StartingPlayerOverlay';
 import { buildDoublesRotation, formatDuration, getOrderedPlayersAndStarter } from '../src/application/scoring/matchLifecycle';
+import {
+    advanceCricketTurn,
+    appendAggregateCricketHit,
+    buildCricketCompetitors,
+    buildCricketHistorySnapshot,
+    buildCricketMatchSummary,
+    type CricketHistorySnapshot,
+    initAggregateCricketStats,
+} from '../src/features/cricket/cricketGameModel';
 
 interface CricketGameViewProps {
     players: Player[];
@@ -24,77 +33,6 @@ interface CricketGameViewProps {
     onFinish: (results: CricketMatchSummary) => void;
     skipStartingPlayerPrompt?: boolean;
 }
-
-type CricketHistorySnapshot = {
-    states: CricketPlayerState[];
-    aggregateStats: CricketPlayerState[];
-    currentThrowerIdx: number;
-    turnDartsThrown: number;
-    orderedPlayers: Player[];
-    winnerId: string | null;
-};
-
-type CricketCompetitor = {
-    id: string;
-    name: string;
-    memberNames: string[];
-};
-
-const cloneCricketStates = (states: CricketPlayerState[]): CricketPlayerState[] =>
-    states.map((state) => ({
-        ...state,
-        marks: { ...state.marks },
-        history: state.history.map((entry) => ({ ...entry })),
-    }));
-
-const clonePlayers = (players: Player[]): Player[] =>
-    players.map((player) => ({ ...player }));
-
-const buildHistorySnapshot = (
-    states: CricketPlayerState[],
-    aggregateStats: CricketPlayerState[],
-    currentThrowerIdx: number,
-    turnDartsThrown: number,
-    orderedPlayers: Player[],
-    winnerId: string | null
-): CricketHistorySnapshot => ({
-    states: cloneCricketStates(states),
-    aggregateStats: cloneCricketStates(aggregateStats),
-    currentThrowerIdx,
-    turnDartsThrown,
-    orderedPlayers: clonePlayers(orderedPlayers),
-    winnerId,
-});
-
-const buildCompetitors = (players: Player[], isDoubles: boolean): CricketCompetitor[] => {
-    if (!isDoubles) {
-        return players.map((player) => ({
-            id: player.id,
-            name: player.name,
-            memberNames: [player.name],
-        }));
-    }
-
-    const groups = players.reduce<Record<string, string[]>>((acc, player) => {
-        acc[player.teamId] = acc[player.teamId] || [];
-        acc[player.teamId].push(player.name);
-        return acc;
-    }, {});
-
-    return Object.entries(groups).map(([teamId, memberNames], index) => ({
-        id: teamId,
-        name: `Equipe ${index + 1}`,
-        memberNames,
-    }));
-};
-
-const initWinCounter = (competitors: CricketCompetitor[]) =>
-    Object.fromEntries(competitors.map((competitor) => [competitor.id, 0])) as Record<string, number>;
-
-const initAggregateStats = (competitors: CricketCompetitor[]): CricketPlayerState[] =>
-    competitors.map((competitor) => ({
-        ...initCricketState([{ id: competitor.id, name: competitor.name, teamId: competitor.id }])[0],
-    }));
 
 export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, config, onExit, onFinish, skipStartingPlayerPrompt = false }) => {
     const initialRotation = useMemo(() => getOrderedPlayersAndStarter(players, config), [players, config]);
@@ -107,7 +45,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
         return starter?.id ?? null;
     }, [config.isDoubles, config.initialStartingTeamId, initialRotation, players]);
     const [orderedPlayers, setOrderedPlayers] = useState<Player[]>(initialRotation.orderedPlayers);
-    const competitors = useMemo(() => buildCompetitors(players, config.isDoubles), [players, config.isDoubles]);
+    const competitors = useMemo(() => buildCricketCompetitors(players, config.isDoubles), [players, config.isDoubles]);
     const memberNamesByCompetitor = useMemo(
         () => Object.fromEntries(competitors.map((competitor) => [competitor.id, competitor.memberNames])),
         [competitors]
@@ -116,7 +54,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
     const [states, setStates] = useState<CricketPlayerState[]>(() =>
         initCricketState(competitors.map((competitor) => ({ id: competitor.id, name: competitor.name, teamId: competitor.id })))
     );
-    const [aggregateStats, setAggregateStats] = useState<CricketPlayerState[]>(() => initAggregateStats(competitors));
+    const [aggregateStats, setAggregateStats] = useState<CricketPlayerState[]>(() => initAggregateCricketStats(competitors));
     const [currentThrowerIdx, setCurrentThrowerIdx] = useState(initialRotation.startingPlayerIndex);
     const [turnDartsThrown, setTurnDartsThrown] = useState(0);
     const [history, setHistory] = useState<CricketHistorySnapshot[]>([]); 
@@ -154,54 +92,6 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
         setStartingCompetitorId(initialStartingCompetitorId);
     }, [initialRotation, initialStartingCompetitorId]);
 
-    const appendAggregateHit = (
-        prev: CricketPlayerState[],
-        competitorId: string,
-        target: CricketTarget | null,
-        multiplier: 1 | 2 | 3,
-        pointsScored: number,
-        isMiss: boolean
-    ) =>
-        prev.map((entry) => {
-            if (entry.id !== competitorId) return entry;
-            const nextMarks = { ...entry.marks };
-            if (target !== null) {
-                nextMarks[target] += multiplier;
-            }
-            return {
-                ...entry,
-                score: entry.score + pointsScored,
-                dartsThrown: entry.dartsThrown + 1,
-                marks: nextMarks,
-                history: [
-                    ...entry.history,
-                    {
-                        target,
-                        multiplier,
-                        isMiss,
-                        pointsScored,
-                    },
-                ],
-            };
-        });
-
-    const buildMatchSummary = (
-        finalCompetitors: CricketPlayerState[],
-        finalWinnerId: string,
-        nextLegsWon: Record<string, number>,
-        nextSetsWon: Record<string, number>,
-        nextSetLegsWon: Record<string, number>
-    ): CricketMatchSummary => ({
-        competitors: finalCompetitors,
-        legsWon: nextLegsWon,
-        setsWon: nextSetsWon,
-        currentSetLegsWon: nextSetLegsWon,
-        winnerId: finalWinnerId,
-        config,
-        isDoubles: config.isDoubles,
-        memberNamesByCompetitor,
-    });
-
     const finishMatch = (
         finalWinnerId: string,
         finalCompetitors: CricketPlayerState[],
@@ -210,7 +100,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
         nextSetLegsWon: Record<string, number>
     ) => {
         setWinnerId(finalWinnerId);
-        onFinish(buildMatchSummary(finalCompetitors, finalWinnerId, nextLegsWon, nextSetsWon, nextSetLegsWon));
+        onFinish(buildCricketMatchSummary(finalCompetitors, finalWinnerId, config, memberNamesByCompetitor, nextLegsWon, nextSetsWon, nextSetLegsWon));
     };
 
     const handleLegWin = (legWinnerId: string, finalCompetitors: CricketPlayerState[]) => {
@@ -222,11 +112,11 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
 
         setHistory((prev) => [
             ...prev,
-            buildHistorySnapshot(states, aggregateStats, currentThrowerIdx, turnDartsThrown, orderedPlayers, winnerId),
+            buildCricketHistorySnapshot(states, aggregateStats, currentThrowerIdx, turnDartsThrown, orderedPlayers, winnerId),
         ]);
 
         const result = processCricketHit(states, currentCompetitorId, target, multiplier);
-        const nextAggregateStats = appendAggregateHit(aggregateStats, currentCompetitorId, target, multiplier, result.pointsScored, false);
+        const nextAggregateStats = appendAggregateCricketHit(aggregateStats, currentCompetitorId, target, multiplier, result.pointsScored, false);
         setStates(result.newStates);
         setAggregateStats(nextAggregateStats);
 
@@ -253,7 +143,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
 
         setHistory((prev) => [
             ...prev,
-            buildHistorySnapshot(states, aggregateStats, currentThrowerIdx, turnDartsThrown, orderedPlayers, winnerId),
+            buildCricketHistorySnapshot(states, aggregateStats, currentThrowerIdx, turnDartsThrown, orderedPlayers, winnerId),
         ]);
 
         const nextStates = states.map((entry) => {
@@ -273,7 +163,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
 
         let nextAggregateStats = aggregateStats;
         for (let i = 0; i < missCount; i += 1) {
-            nextAggregateStats = appendAggregateHit(nextAggregateStats, currentCompetitorId, null, 1, 0, true);
+            nextAggregateStats = appendAggregateCricketHit(nextAggregateStats, currentCompetitorId, null, 1, 0, true);
         }
 
         setStates(nextStates);
@@ -299,13 +189,11 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
     };
 
     const advanceTurn = (dartsAdded: number = 1) => {
-        const nextDartsThrown = turnDartsThrown + dartsAdded;
+        const turnTransition = advanceCricketTurn(turnDartsThrown, orderedPlayers.length, dartsAdded);
 
-        if (nextDartsThrown >= 3) {
-            setTurnDartsThrown(0);
-            setCurrentThrowerIdx(prev => (prev + 1) % orderedPlayers.length);
-        } else {
-            setTurnDartsThrown(nextDartsThrown);
+        setTurnDartsThrown(turnTransition.nextTurnDartsThrown);
+        if (turnTransition.shouldAdvanceThrower) {
+            setCurrentThrowerIdx(prev => (prev + turnTransition.nextThrowerOffset) % orderedPlayers.length);
         }
     };
 
@@ -366,7 +254,7 @@ export const CricketGameView: React.FC<CricketGameViewProps> = ({ players, confi
                      Match remporte
                  </div>
                  <Button
-                    onClick={() => onFinish(buildMatchSummary(aggregateStats, winnerId, { [winnerId]: 1 }, {}, {}))}
+                          onClick={() => onFinish(buildCricketMatchSummary(aggregateStats, winnerId, config, memberNamesByCompetitor, { [winnerId]: 1 }, {}, {}))}
                     size="lg"
                     data-testid="winner-view-stats"
                     className="w-full max-w-xs h-20 text-2xl uppercase shadow-lg shadow-orange-900/40"

--- a/views/GotchaGameView.tsx
+++ b/views/GotchaGameView.tsx
@@ -117,11 +117,11 @@ export const GotchaGameView: React.FC<GotchaGameViewProps> = ({ players, config,
   }
 
   return (
-    <div className="h-[100dvh] overflow-hidden bg-[#06080d] text-white">
+    <div className="min-h-[100dvh] overflow-y-auto bg-[#06080d] text-white xl:h-[100dvh] xl:overflow-hidden">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.18),transparent_25%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.12),transparent_20%),radial-gradient(circle_at_bottom,rgba(255,255,255,0.04),transparent_30%)]" />
       <div className="absolute inset-0 opacity-25 [background-image:linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.03)_1px,transparent_1px)] [background-size:30px_30px]" />
 
-      <div className="relative z-10 mx-auto flex h-[100dvh] min-h-0 w-full max-w-7xl flex-col px-2 py-2 sm:px-6 sm:py-5">
+      <div className="relative z-10 mx-auto flex min-h-[100dvh] w-full max-w-7xl flex-col px-2 py-2 sm:px-6 sm:py-5 xl:h-[100dvh] xl:min-h-0">
         <header className="mb-1 flex shrink-0 flex-wrap items-center justify-between gap-1 sm:mb-5 sm:gap-2">
           <button
             onClick={onExit}
@@ -138,7 +138,7 @@ export const GotchaGameView: React.FC<GotchaGameViewProps> = ({ players, config,
           </div>
         </header>
 
-        <main className="grid min-h-0 flex-1 grid-rows-[minmax(0,0.9fr)_minmax(0,1.2fr)] gap-2 sm:gap-3 lg:grid-cols-[0.95fr_1.05fr] lg:grid-rows-1 lg:gap-5">
+        <main className="grid flex-1 grid-rows-[minmax(16rem,auto)_minmax(24rem,auto)] gap-2 sm:gap-3 xl:min-h-0 xl:grid-cols-[0.95fr_1.05fr] xl:grid-rows-1 xl:gap-5">
           <section className="order-1 flex min-h-0 flex-col rounded-2xl border border-white/10 bg-white/[0.045] p-2 sm:rounded-[1.5rem] sm:p-5">
             <div className="mb-2 flex shrink-0 items-center gap-2 sm:mb-4">
               <Crosshair className="h-4 w-4 text-orange-400 sm:h-5 sm:w-5" />
@@ -172,7 +172,7 @@ export const GotchaGameView: React.FC<GotchaGameViewProps> = ({ players, config,
             </div>
           </section>
 
-          <section className="order-2 flex min-h-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.045] p-2 shadow-[0_20px_55px_rgba(0,0,0,0.28)] sm:rounded-[1.5rem] sm:p-5">
+          <section className="order-2 flex flex-col rounded-2xl border border-white/10 bg-white/[0.045] p-2 shadow-[0_20px_55px_rgba(0,0,0,0.28)] sm:rounded-[1.5rem] sm:p-5 xl:min-h-0 xl:overflow-hidden">
             <div className="mb-2 flex shrink-0 items-start justify-between gap-2 sm:mb-5 sm:gap-3">
               <div className="min-w-0">
                 <p className="text-[10px] font-black uppercase tracking-[0.22em] text-orange-300 sm:text-xs">
@@ -220,7 +220,7 @@ export const GotchaGameView: React.FC<GotchaGameViewProps> = ({ players, config,
               </p>
             </div>
 
-            <div className="grid min-h-0 flex-1 grid-cols-3 grid-rows-4 gap-1.5 sm:gap-2">
+            <div className="grid grid-cols-3 grid-rows-4 gap-1.5 sm:gap-2 xl:min-h-0 xl:flex-1">
               {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map((digit) => (
                 <button
                   key={digit}

--- a/views/HomeView.tsx
+++ b/views/HomeView.tsx
@@ -1,4 +1,4 @@
-// Spec: spec:counter/release-v1.0.1-stabilization
+// Spec: spec:counter/release-v1.1-stabilization
 import React, { useEffect, useId, useRef, useState } from 'react';
 import { ChevronRight, Github, QrCode } from 'lucide-react';
 import { Button } from '../components/ui/Button';
@@ -138,7 +138,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
                 onClick={() => setShowChangelog(true)}
                 className="font-black text-orange-400 underline decoration-orange-400/50 underline-offset-4 transition-colors hover:text-orange-300"
               >
-                {`v1.0.2${buildLabel} (Nouveautes)`}
+                {`v1.1${buildLabel} (Nouveautes)`}
               </button>
               <a
                 href={githubRepositoryUrl}

--- a/views/HomeView.tsx
+++ b/views/HomeView.tsx
@@ -1,6 +1,6 @@
 // Spec: spec:counter/release-v1.0.1-stabilization
 import React, { useEffect, useId, useRef, useState } from 'react';
-import { ChevronRight, Github, MessageCircle, QrCode } from 'lucide-react';
+import { ChevronRight, Github, QrCode } from 'lucide-react';
 import { Button } from '../components/ui/Button';
 import { ChangelogModal } from '../components/ui/ChangelogModal';
 import { InstallAppButton } from '../components/ui/InstallAppButton';
@@ -39,8 +39,7 @@ export const HomeView: React.FC<HomeViewProps> = ({
   }, [showQr]);
 
   const appUrl = env.VITE_APP_URL?.replace(/\/$/, '') || window.location.origin;
-  const feedbackUrl = 'https://chat.whatsapp.com/JCGYsdiNaYHAGAIjTOIaKg?mode=gi_t';
-  const githubIssuesUrl = 'https://github.com/floriangiral/Bougnat_darts_counter/issues';
+  const githubRepositoryUrl = 'https://github.com/floriangiral/Bougnat_darts_counter';
   const shareUrl = appUrl;
   const qrUrl = `/app-qr.svg?appUrl=${encodeURIComponent(shareUrl)}`;
   const normalizedAppEnv = env.VITE_APP_ENV.trim().toLowerCase();
@@ -142,21 +141,11 @@ export const HomeView: React.FC<HomeViewProps> = ({
                 {`v1.0.2${buildLabel} (Nouveautes)`}
               </button>
               <a
-                href={feedbackUrl}
+                href={githubRepositoryUrl}
                 target="_blank"
                 rel="noreferrer"
-                aria-label="Rejoindre le groupe WhatsApp de test"
-                title="Rejoindre le groupe WhatsApp de test"
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-500/10 text-emerald-300 transition-all hover:scale-105 hover:border-emerald-300/60 hover:bg-emerald-500/20 hover:text-white"
-              >
-                <MessageCircle className="h-4 w-4" />
-              </a>
-              <a
-                href={githubIssuesUrl}
-                target="_blank"
-                rel="noreferrer"
-                aria-label="Ouvrir les issues GitHub"
-                title="Ouvrir les issues GitHub"
+                aria-label="Ouvrir le repository GitHub"
+                title="Ouvrir le repository GitHub"
                 className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/15 bg-white/5 text-gray-200 transition-all hover:scale-105 hover:border-white/30 hover:bg-white/10 hover:text-white"
               >
                 <Github className="h-4 w-4" />

--- a/views/MatchView.tsx
+++ b/views/MatchView.tsx
@@ -15,8 +15,9 @@ import { MatchStatusPill } from '../components/match/MatchStatusPill';
 import { MatchTopBar } from '../components/match/MatchTopBar';
 import { env } from '../src/lib/env';
 import { useSharedX01Session } from '../src/features/x01/session/useSharedX01Session';
-import { parseDartsSpeechTranscript } from '../src/features/x01/voice/dartsSpeechParser';
 import type { VoiceScoreProposalState } from '../src/features/x01/voice/dartsSpeechTypes';
+import { buildVoiceScoreProposal } from '../src/features/x01/voice/voiceProposalModel';
+import { buildVoiceRuntimeIssueMessage, buildVoiceStateLabel } from '../src/features/x01/voice/voiceSessionModel';
 import { useDeepgramStreaming } from '../src/features/x01/voice/useDeepgramStreaming';
 import { VoiceScoringControl } from '../src/features/x01/voice/VoiceScoringControl';
 import { buildCheckoutConfirmResult, buildScoreSubmissionResult, cloneMatchState, type FeedbackKind } from '../src/features/x01/scoring/matchSubmission';
@@ -156,8 +157,20 @@ export const MatchView: React.FC<MatchViewProps> = ({
     setVoiceAssistEnabled(true);
   }, [initialMatch.id, restoredState?.match.id, skipStartingPlayerPrompt]);
 
+  const currentPlayer = match.players[match.currentPlayerIndex];
+  const teams = Array.from(new Set(match.players.map(p => p.teamId))) as string[];
+  const currentTeamScore = match.currentLeg.scores[currentPlayer.teamId];
+  const voiceTurnSessionKey = [
+    match.id,
+    match.completedLegs.length,
+    match.currentLeg.history.length,
+    match.currentPlayerIndex,
+    currentPlayer.id,
+  ].join(':');
+
   const {
     error: voiceError,
+    issue: voiceIssue,
     isListening,
     liveTranscript,
     reset: resetVoiceStreaming,
@@ -166,23 +179,24 @@ export const MatchView: React.FC<MatchViewProps> = ({
     stop: stopVoiceStreaming,
   } = useDeepgramStreaming({
     enabled: voiceScoringEnabled,
+    sessionKey: voiceTurnSessionKey,
     onUtterance: ({ transcript, confidence, trigger }) => {
-      const result = parseDartsSpeechTranscript(transcript, {
+      const proposal = buildVoiceScoreProposal({
         confidence,
-        dartsAlreadyThrown: 0,
-        currentRemainingScore: currentTeamScore,
-        startingScoreBeforeTurn: currentTeamScore,
-      });
-
-      setVoiceProposal({
+        context: {
+          currentRemainingScore: currentTeamScore,
+          dartsAlreadyThrown: 0,
+          startingScoreBeforeTurn: currentTeamScore,
+        },
         transcript,
         trigger,
-        result,
       });
 
-      if (result.status !== 'invalid' && result.score !== null) {
+      setVoiceProposal(proposal);
+
+      if (proposal.prefillScore) {
         setRemainingPreview(null);
-        setInputBuffer(String(result.score));
+        setInputBuffer(proposal.prefillScore);
       }
     },
   });
@@ -490,12 +504,10 @@ export const MatchView: React.FC<MatchViewProps> = ({
     }
 
     setVoiceProposal(null);
+    setInputBuffer('');
     void startVoiceStreaming();
   };
 
-  const currentPlayer = match.players[match.currentPlayerIndex];
-  const teams = Array.from(new Set(match.players.map(p => p.teamId))) as string[];
-  const currentTeamScore = match.currentLeg.scores[currentPlayer.teamId];
   const isCurrentPlayerBot = isX01BotPlayer(currentPlayer);
   const isKeyboardLocked = isCurrentPlayerBot || Boolean(botVictoryPreview);
   const matchFormatText = getMatchFormatText(match);
@@ -510,22 +522,16 @@ export const MatchView: React.FC<MatchViewProps> = ({
         : currentTeamScore >= 2 && currentTeamScore <= 180;
   const starterOptions = getStarterOptions(match);
   const canUndoAction = !isKeyboardLocked && Boolean(inputBuffer || pendingCheckoutScore !== null || voiceProposal || voiceError || undoStack.length > 0);
-  const voiceStateLabel =
-    voiceStreamingState === 'processing'
-      ? 'Traitement vocal'
-      : voiceStreamingState === 'listening'
-        ? 'Ecoute en cours'
-        : voiceError
-          ? 'Erreur vocale'
-          : 'Scoring vocal';
+  const voiceStateLabel = buildVoiceStateLabel(voiceStreamingState, voiceIssue);
+  const resolvedVoiceError = voiceError || (voiceIssue ? buildVoiceRuntimeIssueMessage(voiceIssue) : null);
   const showVoicePanel = isListening || Boolean(voiceProposal) || Boolean(voiceError);
   const proposedVoiceScore = voiceProposal;
   const proposedVoiceScoreValue =
     proposedVoiceScore && proposedVoiceScore.result.status !== 'invalid' && proposedVoiceScore.result.score !== null
       ? proposedVoiceScore.result.score
       : null;
-  const voiceHeadline = voiceProposal?.transcript || liveTranscript || voiceError || 'Annonce ton score ou tes fleches';
-  const voiceDisplayText = voiceProposal?.transcript || liveTranscript || voiceError || '';
+  const voiceHeadline = voiceProposal?.transcript || liveTranscript || resolvedVoiceError || 'Annonce ton score ou tes fleches';
+  const voiceDisplayText = voiceProposal?.guidance || voiceProposal?.transcript || liveTranscript || resolvedVoiceError || '';
   const handleStarterSelect = async (starterId: string) => {
     const nextMatch = resolveMatchStart(match, starterId);
     setMatch(nextMatch);
@@ -729,7 +735,7 @@ export const MatchView: React.FC<MatchViewProps> = ({
                     <VoiceScoringControl
                       disabled={!hasGameStarted || isKeyboardLocked || voiceStreamingState === 'processing'}
                       enabled={voiceScoringEnabled}
-                      error={voiceError}
+                      error={resolvedVoiceError}
                       isListening={isListening}
                       onToggle={handleVoiceToggle}
                       stateLabel={voiceStateLabel}

--- a/views/MatchView.tsx
+++ b/views/MatchView.tsx
@@ -22,6 +22,7 @@ import { VoiceScoringControl } from '../src/features/x01/voice/VoiceScoringContr
 import { buildCheckoutConfirmResult, buildScoreSubmissionResult, cloneMatchState, type FeedbackKind } from '../src/features/x01/scoring/matchSubmission';
 import { deriveRemainingPreview, type RemainingPreview } from '../src/features/x01/scoring/matchPreview';
 import { getFeedbackStyles } from '../src/features/x01/scoring/matchFeedback';
+import { resolveBotVictoryPreview } from '../src/features/x01/scoring/botVictoryPreview';
 import { getMatchFormatCompactText, getMatchFormatText, getStarterOptions, getWinnerDisplayName } from '../src/features/x01/scoring/matchPresentation';
 import { buildPlayerScoreViewModel } from '../src/features/x01/scoring/matchPlayerScore';
 import { buildX01BotTurnResult } from '../src/application/x01Bot/x01BotTurn';
@@ -568,11 +569,12 @@ export const MatchView: React.FC<MatchViewProps> = ({
         level: currentPlayer.botLevel ?? DEFAULT_X01_BOT_LEVEL,
         elapsedSeconds,
       });
-      const completedLeg = result.nextMatch.completedLegs[result.nextMatch.completedLegs.length - 1];
-      const hasBotWonLeg =
-        result.nextMatch.matchWinnerId === currentPlayer.teamId
-        || completedLeg?.winnerId === currentPlayer.teamId
-        || result.nextMatch.currentLeg.winnerId === currentPlayer.teamId;
+      const { hasBotWonLeg, hasBotWonMatch, previewKind } = resolveBotVictoryPreview({
+        previousMatch: match,
+        nextMatch: result.nextMatch,
+        currentPlayerTeamId: currentPlayer.teamId,
+        showWinnerScreen: result.showWinnerScreen,
+      });
 
       setUndoStack((prev) => [
         ...prev,
@@ -591,13 +593,13 @@ export const MatchView: React.FC<MatchViewProps> = ({
       setRemainingPreview(null);
       resetVoiceStreaming();
       void persistSharedState(result.persistMatch);
-      if (hasBotWonLeg) {
+      if (hasBotWonMatch || hasBotWonLeg) {
         showBotVictoryPreview(
           {
-            kind: result.showWinnerScreen ? 'match' : 'leg',
+            kind: previewKind ?? 'leg',
             winnerName: currentPlayer.name,
           },
-          result.showWinnerScreen ? () => setShowWinnerScreen(true) : undefined,
+          hasBotWonMatch ? () => setShowWinnerScreen(true) : undefined,
         );
       } else {
         setShowWinnerScreen(result.showWinnerScreen);

--- a/views/SetupView.tsx
+++ b/views/SetupView.tsx
@@ -289,7 +289,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                       isCustomActive && !presets.includes(startingScore) ? activeOptionClass : inactiveOptionClass
                     }`}
                   >
-                    {isCustomActive && hasCustomScoreValue ? customScoreStr : 'Perso'}
+                    {gameType === 'GOTCHA' ? 'PERSO' : isCustomActive && hasCustomScoreValue ? customScoreStr : 'Perso'}
                   </button>
                 </div>
                 {isCustomActive && !isCustomScoreValid && (

--- a/views/SetupView.tsx
+++ b/views/SetupView.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect, useReducer, useState } from 'react';
-import { ArrowLeft, Bot, Swords, Users } from 'lucide-react';
-import { Button } from '../components/ui/Button';
+import { ArrowLeft } from 'lucide-react';
 import { Player, GameConfig, InOutRule, MatchMode } from '../types';
 import type { GameType } from '../utils/arenaFlow';
+import { SetupPlayersSection } from '../components/game-setup/SetupPlayersSection';
 import { SetupCustomNumberModal } from '../components/game-setup/SetupCustomNumberModal';
-import { PlayerNameField } from '../components/game-setup/PlayerNameField';
+import { SetupSummarySection } from '../components/game-setup/SetupSummarySection';
 import { SetupRulesModal } from '../components/game-setup/SetupRulesModal';
+import {
+  setupActiveOptionClass,
+  setupInactiveOptionClass,
+  setupLabelClass,
+  setupSectionClass,
+} from '../components/game-setup/setupViewStyles';
 import {
   buildSetupConfig,
   buildSetupPlayers,
@@ -15,13 +21,12 @@ import {
 } from '../src/features/game-setup/setupModel';
 import {
   getGameName,
-  getMatchModeLabel,
   getRuleDescription,
   getRuleLabel,
   getRulesContent,
   getSetupTitle,
 } from '../src/features/game-setup/setupPresentation';
-import { formatX01BotAverageRange, X01_BOT_LEVELS } from '../src/domain/x01Bot/x01Bot';
+import { buildSetupSummaryEntries } from '../src/features/game-setup/setupViewModel';
 
 interface SetupViewProps {
   gameType?: GameType;
@@ -42,12 +47,6 @@ interface SetupViewProps {
     teamStarterIds: Record<string, string>;
   }>;
 }
-
-const sectionClass = 'rounded-[1.75rem] border border-white/10 bg-white/[0.04] p-5 shadow-[0_16px_40px_rgba(0,0,0,0.2)] backdrop-blur-sm';
-const labelClass = 'mb-3 block text-[11px] font-black uppercase tracking-[0.28em] text-orange-300';
-const activeOptionClass = 'bg-gradient-to-r from-orange-600 to-red-600 text-white border-transparent shadow-[0_0_14px_rgba(234,88,12,0.35)]';
-const inactiveOptionClass = 'bg-white/[0.04] border-white/10 text-gray-400 hover:border-orange-500/40 hover:text-white';
-
 
 export const SetupView: React.FC<SetupViewProps> = ({
   onStart,
@@ -173,7 +172,18 @@ export const SetupView: React.FC<SetupViewProps> = ({
   const isCustomScoreLaunchBlocked = launchState.isCustomScoreLaunchBlocked;
   const isCustomLegsLaunchBlocked = launchState.isCustomLegsLaunchBlocked;
   const rulesContent = getRulesContent(gameType, cricketRounds, checkIn, checkOut);
-  const canPlayAgainstBot = gameType === 'X01' && !isDoubles;
+  const summaryEntries = buildSetupSummaryEntries({
+    gameType,
+    startingScore,
+    matchMode,
+    legsToWin,
+    setsToWin,
+    cricketRounds,
+    isDoubles,
+    playerCount: playerNames.length,
+    checkIn,
+    checkOut,
+  });
 
   const handleCustomFocus = () => {
     const value = parseInt(customScoreStr, 10);
@@ -264,14 +274,14 @@ export const SetupView: React.FC<SetupViewProps> = ({
         <div className="grid gap-5 lg:grid-cols-[1.3fr_0.7fr]">
           <div className="space-y-5">
             {(gameType === 'X01' || gameType === 'GOTCHA') && (
-              <section className={sectionClass}>
-                <label className={labelClass}>{gameType === 'GOTCHA' ? 'Score Cible' : 'Score De Depart'}</label>
+              <section className={setupSectionClass}>
+                <label className={setupLabelClass}>{gameType === 'GOTCHA' ? 'Score Cible' : 'Score De Depart'}</label>
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
                   {presets.map((score) => (
                     <button
                       key={score}
                       onClick={() => dispatch({ type: 'set_starting_score', value: score })}
-                      className={`rounded-2xl border py-3 text-sm font-black transition-all duration-200 ${startingScore === score ? activeOptionClass : inactiveOptionClass}`}
+                      className={`rounded-2xl border py-3 text-sm font-black transition-all duration-200 ${startingScore === score ? setupActiveOptionClass : setupInactiveOptionClass}`}
                     >
                       {score}
                     </button>
@@ -286,7 +296,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                       setIsCustomScoreOpen(true);
                     }}
                     className={`rounded-2xl border py-3 text-sm font-black transition-all duration-200 ${
-                      isCustomActive && !presets.includes(startingScore) ? activeOptionClass : inactiveOptionClass
+                      isCustomActive && !presets.includes(startingScore) ? setupActiveOptionClass : setupInactiveOptionClass
                     }`}
                   >
                     {gameType === 'GOTCHA' ? 'PERSO' : isCustomActive && hasCustomScoreValue ? customScoreStr : 'Perso'}
@@ -300,206 +310,27 @@ export const SetupView: React.FC<SetupViewProps> = ({
               </section>
             )}
 
-            <section className={sectionClass}>
-              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <label className={`${labelClass} mb-0`}>Joueurs</label>
-                {(gameType === 'X01' || gameType === 'CRICKET' || gameType === 'TRIATHLON') && (
-                  <div className="inline-flex rounded-2xl border border-white/10 bg-black/20 p-1">
-                    <button
-                      onClick={() => dispatch({ type: 'set_is_doubles', value: false })}
-                      className={`rounded-xl px-4 py-2 text-xs font-black uppercase tracking-[0.18em] transition-all ${!isDoubles ? 'bg-white/10 text-white' : 'text-gray-500 hover:text-white'}`}
-                    >
-                      <Users className="mr-2 inline h-4 w-4" />
-                      Simple
-                    </button>
-                    <button
-                      onClick={() => dispatch({ type: 'set_is_doubles', value: true })}
-                      className={`rounded-xl px-4 py-2 text-xs font-black uppercase tracking-[0.18em] transition-all ${isDoubles ? 'bg-white/10 text-white' : 'text-gray-500 hover:text-white'}`}
-                    >
-                      <Swords className="mr-2 inline h-4 w-4" />
-                      Doublettes
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              {!isDoubles ? (
-                <>
-                  <div className="mb-5 rounded-2xl border border-white/10 bg-black/20 p-4">
-                      <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Nombre De Joueurs</div>
-                      <div className="grid grid-cols-4 gap-2">
-                        {(
-                          gameType === 'CRICKET'
-                            ? [2, 3]
-                            : gameType === 'KILLER' || gameType === 'GOTCHA'
-                              ? [2, 3, 4, 5, 6]
-                            : gameType === 'TRIATHLON'
-                              ? [2]
-                              : gameType === 'X01'
-                                ? [1, 2]
-                                : [1, 2, 3, 4]
-                        ).map((count) => (
-                          <button
-                            key={count}
-                            type="button"
-                            onClick={() => setPlayerCount(count)}
-                            className={`rounded-xl border py-2 text-sm font-black transition-all ${playerNames.length === count ? activeOptionClass : inactiveOptionClass}`}
-                          >
-                            {count}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-
-                  <div className="space-y-3">
-                    {(!playAgainstBot ? playerNames : playerNames.slice(0, 1)).map((name, index) => (
-                      <PlayerNameField
-                        key={index}
-                        label={`Joueur ${index + 1}`}
-                        value={name}
-                        placeholder={`Joueur ${index + 1}`}
-                        onChange={(value) => updatePlayerName(index, value)}
-                      />
-                    ))}
-                    {canPlayAgainstBot && playAgainstBot && (
-                      <div className="rounded-2xl border border-orange-500/25 bg-orange-500/[0.06] px-4 py-3">
-                        <div className="mb-2 flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">
-                          <Bot className="h-4 w-4" />
-                          Adversaire robot
-                        </div>
-                        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-lg font-black text-white">
-                          Robot {X01_BOT_LEVELS.find((definition) => definition.level === botLevel)?.label ?? 'Amateur'}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  {canPlayAgainstBot && (
-                    <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 p-4">
-                      <label className="flex cursor-pointer items-center gap-3">
-                        <input
-                          type="checkbox"
-                          checked={playAgainstBot}
-                          onChange={(event) => dispatch({ type: 'set_play_against_bot', gameType, value: event.target.checked })}
-                          className="h-5 w-5 rounded border-white/20 bg-white/10 accent-orange-600"
-                        />
-                        <span className="text-sm font-black uppercase tracking-[0.16em] text-white">
-                          Jouer contre un robot
-                        </span>
-                      </label>
-
-                      {playAgainstBot && (
-                        <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
-                          {X01_BOT_LEVELS.map((definition) => (
-                            <label
-                              key={definition.level}
-                              className={`cursor-pointer rounded-xl border px-3 py-3 transition-all ${
-                                botLevel === definition.level ? activeOptionClass : inactiveOptionClass
-                              }`}
-                            >
-                              <input
-                                type="checkbox"
-                                checked={botLevel === definition.level}
-                                onChange={() => dispatch({ type: 'set_bot_level', value: definition.level })}
-                                className="sr-only"
-                              />
-                              <span className="block text-xs font-black uppercase tracking-[0.16em]">
-                                {definition.label}
-                              </span>
-                              <span className="mt-1 block text-[10px] font-bold uppercase leading-tight text-current opacity-75">
-                                {formatX01BotAverageRange(definition)}
-                              </span>
-                            </label>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </>
-              ) : (
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                    <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">Joueurs 1 / 2</div>
-                    <div className="space-y-3">
-                      <PlayerNameField
-                        label="Joueur 1"
-                        value={team1Names[0]}
-                        placeholder="Joueur 1"
-                        onChange={(value) => updateTeamName(1, 0, value)}
-                        compact
-                      />
-                      <PlayerNameField
-                        label="Joueur 2"
-                        value={team1Names[1]}
-                        placeholder="Joueur 2"
-                        onChange={(value) => updateTeamName(1, 1, value)}
-                        compact
-                      />
-                    </div>
-                    <div className="mt-4">
-                      <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Qui commence dans ce duo ?</div>
-                      <div className="grid grid-cols-2 gap-2">
-                        {[
-                          { id: 't1p1', label: team1Names[0].trim() || 'Joueur 1' },
-                          { id: 't1p2', label: team1Names[1].trim() || 'Joueur 2' },
-                        ].map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => updateTeamStarter('team1', option.id)}
-                            className={`rounded-xl border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] ${teamStarterIds.team1 === option.id ? activeOptionClass : inactiveOptionClass}`}
-                          >
-                            {option.label}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                    <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-orange-300">Joueurs 3 / 4</div>
-                    <div className="space-y-3">
-                      <PlayerNameField
-                        label="Joueur 3"
-                        value={team2Names[0]}
-                        placeholder="Joueur 3"
-                        onChange={(value) => updateTeamName(2, 0, value)}
-                        compact
-                      />
-                      <PlayerNameField
-                        label="Joueur 4"
-                        value={team2Names[1]}
-                        placeholder="Joueur 4"
-                        onChange={(value) => updateTeamName(2, 1, value)}
-                        compact
-                      />
-                    </div>
-                    <div className="mt-4">
-                      <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Qui commence dans ce duo ?</div>
-                      <div className="grid grid-cols-2 gap-2">
-                        {[
-                          { id: 't2p1', label: team2Names[0].trim() || 'Joueur 3' },
-                          { id: 't2p2', label: team2Names[1].trim() || 'Joueur 4' },
-                        ].map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => updateTeamStarter('team2', option.id)}
-                            className={`rounded-xl border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] ${teamStarterIds.team2 === option.id ? activeOptionClass : inactiveOptionClass}`}
-                          >
-                            {option.label}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </section>
+            <SetupPlayersSection
+              gameType={gameType}
+              isDoubles={isDoubles}
+              playerNames={playerNames}
+              team1Names={team1Names}
+              team2Names={team2Names}
+              teamStarterIds={teamStarterIds}
+              playAgainstBot={playAgainstBot}
+              botLevel={botLevel}
+              onSetDoubles={(value) => dispatch({ type: 'set_is_doubles', value })}
+              onSetPlayerCount={setPlayerCount}
+              onUpdatePlayerName={updatePlayerName}
+              onUpdateTeamName={updateTeamName}
+              onUpdateTeamStarter={updateTeamStarter}
+              onToggleBot={(value) => dispatch({ type: 'set_play_against_bot', gameType, value })}
+              onSetBotLevel={(value) => dispatch({ type: 'set_bot_level', value })}
+            />
 
             {gameType === 'CRICKET' && (
-              <section className={sectionClass}>
-                <label className={labelClass}>Nombre De Tours</label>
+              <section className={setupSectionClass}>
+                <label className={setupLabelClass}>Nombre De Tours</label>
                 <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
                   <div className="grid grid-cols-3 gap-2">
                     {([10, 20, 30] as const).map((rounds) => (
@@ -507,7 +338,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                         key={rounds}
                         type="button"
                         onClick={() => dispatch({ type: 'set_cricket_rounds', value: rounds })}
-                        className={`rounded-xl border py-3 text-sm font-black transition-all ${cricketRounds === rounds ? activeOptionClass : inactiveOptionClass}`}
+                        className={`rounded-xl border py-3 text-sm font-black transition-all ${cricketRounds === rounds ? setupActiveOptionClass : setupInactiveOptionClass}`}
                       >
                         {rounds}
                       </button>
@@ -518,8 +349,8 @@ export const SetupView: React.FC<SetupViewProps> = ({
             )}
 
             {gameType === 'X01' && (
-              <section className={sectionClass}>
-                <label className={labelClass}>Format Du Match</label>
+              <section className={setupSectionClass}>
+                <label className={setupLabelClass}>Format Du Match</label>
 
                 <div className="mb-5 inline-flex rounded-2xl border border-white/10 bg-black/20 p-1">
                   <button onClick={() => dispatch({ type: 'set_match_mode', value: 'LEGS' })} className={`rounded-xl px-4 py-2 text-xs font-black uppercase tracking-[0.18em] transition-all ${matchMode === 'LEGS' ? 'bg-white/10 text-white' : 'text-gray-500 hover:text-white'}`}>
@@ -536,14 +367,14 @@ export const SetupView: React.FC<SetupViewProps> = ({
                       <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Manches Pour Gagner Le Match</div>
                       <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
                         {presetLegsOptions.map((num) => (
-                          <button key={num} onClick={() => dispatch({ type: 'set_legs_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${legsToWin === num ? activeOptionClass : inactiveOptionClass}`}>
+                          <button key={num} onClick={() => dispatch({ type: 'set_legs_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${legsToWin === num ? setupActiveOptionClass : setupInactiveOptionClass}`}>
                             {num}
                           </button>
                         ))}
                         <button
                           type="button"
                           onClick={() => setIsCustomLegsOpen(true)}
-                          className={`rounded-xl border py-2 text-sm font-black ${isCustomLegsActive ? activeOptionClass : inactiveOptionClass}`}
+                          className={`rounded-xl border py-2 text-sm font-black ${isCustomLegsActive ? setupActiveOptionClass : setupInactiveOptionClass}`}
                         >
                           {isCustomLegsActive && hasCustomLegsValue ? customLegsStr : 'Perso'}
                         </button>
@@ -560,7 +391,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                         <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Sets Pour Gagner Le Match</div>
                         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                           {[1, 3, 5, 7].map((num) => (
-                            <button key={num} onClick={() => dispatch({ type: 'set_sets_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${setsToWin === num ? activeOptionClass : inactiveOptionClass}`}>
+                            <button key={num} onClick={() => dispatch({ type: 'set_sets_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${setsToWin === num ? setupActiveOptionClass : setupInactiveOptionClass}`}>
                               {num}
                             </button>
                           ))}
@@ -570,7 +401,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                         <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Manches Pour Gagner Un Set</div>
                         <div className="grid grid-cols-2 gap-2">
                           {[3, 5].map((num) => (
-                            <button key={num} onClick={() => dispatch({ type: 'set_legs_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${legsToWin === num ? activeOptionClass : inactiveOptionClass}`}>
+                            <button key={num} onClick={() => dispatch({ type: 'set_legs_to_win', value: num })} className={`rounded-xl border py-2 text-sm font-black ${legsToWin === num ? setupActiveOptionClass : setupInactiveOptionClass}`}>
                               {num}
                             </button>
                           ))}
@@ -583,14 +414,14 @@ export const SetupView: React.FC<SetupViewProps> = ({
             )}
 
             {gameType === 'X01' && (
-              <section className={sectionClass}>
-                <label className={labelClass}>Regles</label>
+              <section className={setupSectionClass}>
+                <label className={setupLabelClass}>Regles</label>
                 <div className="grid gap-5 md:grid-cols-2">
                   <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
                     <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Ouverture</div>
                     <div className="grid grid-cols-3 gap-2">
                       {(['Open', 'Double', 'Master'] as const).map((rule) => (
-                        <button key={rule} onClick={() => dispatch({ type: 'set_check_in', value: rule })} className={`rounded-xl border px-2 py-2 text-[11px] font-black uppercase tracking-[0.14em] ${checkIn === rule ? activeOptionClass : inactiveOptionClass}`}>
+                        <button key={rule} onClick={() => dispatch({ type: 'set_check_in', value: rule })} className={`rounded-xl border px-2 py-2 text-[11px] font-black uppercase tracking-[0.14em] ${checkIn === rule ? setupActiveOptionClass : setupInactiveOptionClass}`}>
                           {getRuleLabel(rule)}
                         </button>
                       ))}
@@ -602,7 +433,7 @@ export const SetupView: React.FC<SetupViewProps> = ({
                     <div className="mb-3 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Fermeture</div>
                     <div className="grid grid-cols-3 gap-2">
                       {(['Open', 'Double', 'Master'] as const).map((rule) => (
-                        <button key={rule} onClick={() => dispatch({ type: 'set_check_out', value: rule })} className={`rounded-xl border px-2 py-2 text-[11px] font-black uppercase tracking-[0.14em] ${checkOut === rule ? activeOptionClass : inactiveOptionClass}`}>
+                        <button key={rule} onClick={() => dispatch({ type: 'set_check_out', value: rule })} className={`rounded-xl border px-2 py-2 text-[11px] font-black uppercase tracking-[0.14em] ${checkOut === rule ? setupActiveOptionClass : setupInactiveOptionClass}`}>
                           {getRuleLabel(rule)}
                         </button>
                       ))}
@@ -616,102 +447,11 @@ export const SetupView: React.FC<SetupViewProps> = ({
           </div>
 
           <aside className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-            <section className={sectionClass}>
-              <label className={labelClass}>Resume Du Match</label>
-              <div className="space-y-4">
-                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                  <div className="mb-2 text-[10px] font-black uppercase tracking-[0.24em] text-gray-500">Configuration</div>
-                  <div className="space-y-2 text-sm text-gray-300">
-                    <div className="flex items-center justify-between">
-                      <span>Jeu</span>
-                      <span className="font-black text-white">{getGameName(gameType)}</span>
-                    </div>
-                    {gameType === 'TRIATHLON' && (
-                      <>
-                        <div className="flex items-center justify-between">
-                          <span>Ordre Des Jeux</span>
-                          <span className="font-black text-white">Capital / Cricket / 501</span>
-                        </div>
-                        <div className="flex items-center justify-between">
-                          <span>Format</span>
-                          <span className="font-black text-white">{isDoubles ? 'Doublettes' : 'Individuel'}</span>
-                        </div>
-                      </>
-                    )}
-                    {(gameType === 'X01' || gameType === 'CRICKET' || gameType === 'GOTCHA') && (
-                      <>
-                        {(gameType === 'X01' || gameType === 'GOTCHA') && (
-                          <div className="flex items-center justify-between">
-                            <span>{gameType === 'GOTCHA' ? 'Score Cible' : 'Score De Depart'}</span>
-                            <span className="font-black text-white">{startingScore}</span>
-                          </div>
-                        )}
-                        {gameType === 'X01' && (
-                          <div className="flex items-center justify-between">
-                            <span>Format</span>
-                            <span className="font-black text-white">{getMatchModeLabel(matchMode)}</span>
-                          </div>
-                        )}
-                        {gameType === 'CRICKET' && (
-                          <div className="flex items-center justify-between">
-                            <span>Nombre De Tours</span>
-                            <span className="font-black text-white">{cricketRounds}</span>
-                          </div>
-                        )}
-                        {gameType === 'CRICKET' && (
-                          <div className="flex items-center justify-between">
-                            <span>Nombre De Joueurs</span>
-                            <span className="font-black text-white">{isDoubles ? 4 : playerNames.length}</span>
-                          </div>
-                        )}
-                        {gameType === 'GOTCHA' && (
-                          <div className="flex items-center justify-between">
-                            <span>Nombre De Joueurs</span>
-                            <span className="font-black text-white">{playerNames.length}</span>
-                          </div>
-                        )}
-                        {gameType === 'X01' && matchMode === 'LEGS' && (
-                          <div className="flex items-center justify-between">
-                            <span>Manches Pour Gagner</span>
-                            <span className="font-black text-white">{legsToWin}</span>
-                          </div>
-                        )}
-                        {gameType === 'X01' && matchMode === 'SETS' && (
-                          <>
-                            <div className="flex items-center justify-between">
-                              <span>Sets Pour Gagner</span>
-                              <span className="font-black text-white">{setsToWin}</span>
-                            </div>
-                            <div className="flex items-center justify-between">
-                              <span>Manches Par Set</span>
-                              <span className="font-black text-white">{legsToWin}</span>
-                            </div>
-                          </>
-                        )}
-                        {gameType === 'X01' && (
-                          <div className="flex items-center justify-between">
-                            <span>Ouverture / Fermeture</span>
-                            <span className="font-black text-white">{getRuleLabel(checkIn)} / {getRuleLabel(checkOut)}</span>
-                          </div>
-                        )}
-                        <div className="flex items-center justify-between">
-                            <span>Mode</span>
-                            <span className="font-black text-white">{isDoubles ? 'Doublettes' : 'Simple'}</span>
-                          </div>
-                      </>
-                    )}
-                  </div>
-                </div>
-
-                <Button
-                  onClick={handleStart}
-                  disabled={isCustomScoreLaunchBlocked || isCustomLegsLaunchBlocked}
-                  className="h-16 w-full rounded-2xl text-xl shadow-[0_18px_40px_rgba(234,88,12,0.28)] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none"
-                >
-                  Lancer La Partie
-                </Button>
-              </div>
-            </section>
+            <SetupSummarySection
+              entries={summaryEntries}
+              isLaunchBlocked={isCustomScoreLaunchBlocked || isCustomLegsLaunchBlocked}
+              onStart={handleStart}
+            />
           </aside>
         </div>
       </div>

--- a/views/TriathlonGameView.tsx
+++ b/views/TriathlonGameView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useReducer, useState } from 'react';
-import { Player, MatchState, CricketMatchSummary, CapitalPlayerState, GameConfig, BullAttempt, TriathlonResults } from '../types';
+import { Player, MatchState, CricketMatchSummary, CapitalPlayerState, GameConfig, TriathlonResults } from '../types';
 import { createMatch, formatDuration } from '../src/application/scoring/matchLifecycle';
 import { MatchView } from './MatchView';
 import { CricketGameView } from './CricketGameView';
@@ -10,9 +10,9 @@ import {
   buildTriathlonCompetitors,
   createInitialTriathlonFlowState,
   finalizeTriathlonResults,
-  getAttemptValue,
   triathlonFlowReducer,
 } from '../src/features/triathlon/triathlonFlow';
+import { StartingPlayerOverlay } from '../components/game/StartingPlayerOverlay';
 import { TriathlonGameHeader } from '../components/triathlon/TriathlonGameHeader';
 import { TriathlonStandingCard } from '../components/triathlon/TriathlonStandingCard';
 import { TriathlonTransitionRecap } from '../components/triathlon/TriathlonTransitionRecap';
@@ -31,7 +31,7 @@ export const TriathlonGameView: React.FC<TriathlonGameViewProps> = ({ players, c
   const [showStats, setShowStats] = useState(false);
   const [currentTime, setCurrentTime] = useState<string>(new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', hour12: false }));
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const { phase, results, startingCompetitorId, starterDrawAttempts, starterDrawMessage, scorecards } = flowState;
+  const { phase, results, startingCompetitorId, scorecards } = flowState;
 
   const triathlonCompetitors = useMemo(
     () => buildTriathlonCompetitors(players, config.isDoubles),
@@ -133,32 +133,11 @@ export const TriathlonGameView: React.FC<TriathlonGameViewProps> = ({ players, c
       x01Match: nextResults.x01 ?? null,
     });
 
-  const handleStarterAttempt = (competitorId: string, attempt: BullAttempt) => {
-    const nextAttempts = { ...starterDrawAttempts, [competitorId]: attempt };
-
-    const pendingCompetitors = triathlonCompetitors.filter((entry) => nextAttempts[entry.id] === undefined);
-    if (pendingCompetitors.length > 0) {
-      dispatch({ type: 'starter_attempts_updated', attempts: nextAttempts });
-      return;
-    }
-
-    const maxValue = Math.max(...triathlonCompetitors.map((entry) => getAttemptValue(nextAttempts[entry.id])));
-    const leaders = triathlonCompetitors.filter((entry) => getAttemptValue(nextAttempts[entry.id]) === maxValue);
-
-    if (leaders.length > 1) {
-      dispatch({
-        type: 'starter_attempts_updated',
-        attempts: Object.fromEntries(leaders.map((entry) => [entry.id, undefined])),
-        message: 'Egalite sur le tir a la bulle. Relance uniquement entre les equipes ou joueurs a egalite.',
-      });
-      return;
-    }
-
-    const starterId = leaders[0]?.id || triathlonCompetitors[0]?.id || null;
+  const handleStarterSelect = (starterId: string) => {
     dispatch({
       type: 'starter_resolved',
-      starterId,
-      attempts: nextAttempts,
+      starterId: starterId || triathlonCompetitors[0]?.id || null,
+      attempts: {},
       triathlonCompetitors,
     });
   };
@@ -227,62 +206,12 @@ export const TriathlonGameView: React.FC<TriathlonGameViewProps> = ({ players, c
   };
 
   if (phase === 'STARTING_DRAW') {
-    const drawEntries =
-      Object.keys(starterDrawAttempts).length > 0
-        ? triathlonCompetitors.filter((entry) => starterDrawAttempts[entry.id] === undefined)
-        : triathlonCompetitors;
-
     return (
-      <div className="flex h-[100dvh] flex-col overflow-hidden bg-black text-white">
-        <TriathlonGameHeader
-          currentTime={currentTime}
-          elapsedSeconds={elapsedSeconds}
-          onShowStats={() => setShowStats(true)}
-          onShowExitConfirm={() => setShowExitConfirm(true)}
-        />
-        <div className="flex flex-1 flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-6">
-          <h1 className="text-center text-3xl font-black italic uppercase text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-red-500 sm:text-5xl">
-            Tir a la bulle
-          </h1>
-          <p className="max-w-2xl text-center text-sm text-gray-300 sm:text-base">{starterDrawMessage}</p>
-          <div className="grid w-full max-w-4xl gap-4 sm:grid-cols-2">
-            {drawEntries.map((entry) => (
-              <div key={entry.id} className="rounded-2xl border border-gray-800 bg-gray-900 p-4 shadow-2xl sm:p-5">
-                <div className="mb-4 text-center text-lg font-black uppercase text-white">{entry.name}</div>
-                <div className="grid grid-cols-3 gap-3">
-                  <Button onClick={() => handleStarterAttempt(entry.id, 'DOUBLE_BULL')} className="h-14 border-none bg-gradient-to-r from-red-600 to-orange-600 text-sm font-black uppercase">
-                    D-Bull
-                  </Button>
-                  <Button onClick={() => handleStarterAttempt(entry.id, 'BULL')} className="h-14 border-none bg-gradient-to-r from-green-600 to-emerald-600 text-sm font-black uppercase">
-                    Bull
-                  </Button>
-                  <Button variant="secondary" onClick={() => handleStarterAttempt(entry.id, 'MISS')} className="h-14 text-sm font-black uppercase">
-                    Miss
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-        {showStats && (
-          <TriathlonStatsModal
-            scorecards={rankedScorecards}
-            tieBreakWinnerId={results.tieBreakWinnerId}
-            onClose={() => setShowStats(false)}
-          />
-        )}
-        {showExitConfirm && (
-          <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/90 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-sm rounded-xl border border-gray-700 bg-gray-900 p-6 text-center shadow-2xl">
-              <h3 className="mb-2 text-2xl font-black italic uppercase text-white">Quitter ?</h3>
-              <div className="mt-8 grid grid-cols-2 gap-3">
-                <Button variant="secondary" onClick={() => setShowExitConfirm(false)}>Non</Button>
-                <Button variant="danger" onClick={onExit}>Oui</Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+      <StartingPlayerOverlay
+        options={triathlonCompetitors.map((entry) => ({ id: entry.id, label: entry.name }))}
+        onSelect={handleStarterSelect}
+        onCancel={onExit}
+      />
     );
   }
 


### PR DESCRIPTION
## Objectif

Publier la release stable open source `v1.1` de `Bougnat_darts_counter`.

## Périmètre

- moteur de scoring local
- jeux supportés : X01, 501 Double Out, Cricket, Capital, Triathlon, Killer, Gotcha
- voice scoring X01 optionnel avec fallback manuel
- sessions locales, reprise locale, expérience offline-first
- clarification du périmètre open source et de la gouvernance release

## Inclus dans cette release

- réalignement complet de `develop` avec les commits validés de `release/1.0.2`
- suppression du faux contrat `VITE_TOURNAMENT_API_URL`
- passage de la version package à `1.1.0`
- ajout de la spec `026-counter-release-v1-1-stabilization`
- publication des notes `docs/release/v1.1.md`
- publication de la coverage map `docs/release/v1.1-coverage-map.md`
- actualisation du footer home et du changelog utilisateur sur `v1.1`

## Validations exécutées

- `npm run ci:check` sur `develop`: OK
- `npm run ci:check` sur `release/1.1`: OK
- `npm run test:e2e` sur `release/1.1`: OK (`13` smoke tests)
- tag `v1.1` créé sur `release/1.1`

## Points restants hors environnement local

- `npm run preprod:check`: échec local attendu faute de variables GitHub Environment injectées (`VITE_APP_ENV`, `VITE_APP_URL`)
- `npm run production:check`: échec local attendu pour la même raison

## Références

Refs: #103
Refs: #94
Refs: #95
Refs: #96
Refs: #97
Refs: #98
Refs: #99
Refs: spec:counter/release-v1.1-stabilization
