### PR TITLE
fix(ci): corriger le miroir production via pull request

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   promote:
@@ -59,15 +59,6 @@ jobs:
             echo "confirm_target must equal production." >&2
             exit 1
           fi
-
-      - name: Create branch promoter app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.BRANCH_PROMOTER_APP_ID }}
-          private-key: ${{ secrets.BRANCH_PROMOTER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -120,7 +111,7 @@ jobs:
       - name: Sync production mirror branch
         run: |
           git fetch origin production || true
-          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/production --force
+          git push "https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/production --force
 
       - name: Deployment summary
         run: |

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -136,6 +136,7 @@ Regles de securite recommandees dans GitHub :
 - environment `production` : limiter les deploiements a la branche `main`
 - environment `production` : exiger au moins un reviewer manuel avant execution
 - conserver les secrets uniquement au niveau des environments qui les utilisent
+- le workflow `Promote Production` peut pousser la branche miroir `production` avec le `GITHUB_TOKEN`, sans GitHub App dediee
 
 ## Documentation technique
 


### PR DESCRIPTION
## Résumé

Cette PR met à jour `main` avec le correctif du workflow `Promote Production` ajouté après la PR de release précédente.

## Changement principal

- suppression de la dépendance à une GitHub App pour pousser la branche miroir `production`
- utilisation directe du `GITHUB_TOKEN` avec `contents: write`
- mise à jour de la documentation technique associée

## Pourquoi

Le workflow échouait sur `Sync production mirror branch` avec une erreur `403` pour `github-actions[bot]`. Ce correctif simplifie la chaîne CI et fiabilise la promotion production.

## Vérification

- workflow modifié dans `.github/workflows/promote-production.yml`
- doc mise à jour dans `docs/technical.md`
- branche source : `release/1.1`
- commit principal : `494e19e`
