### PR TITLE
fix(deploy): documenter le flux Cloudflare Pages

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -80,6 +80,7 @@ Regles importantes :
 ```bash
 npm run dev
 npm run build
+npm run deploy:pages
 npm run preview
 npm run lint
 npm run typecheck
@@ -87,6 +88,19 @@ npm run test:unit
 npm run test:e2e
 npm run ci:check
 ```
+
+## Deploiement Cloudflare Pages
+
+Le repo est configure pour un projet `Cloudflare Pages`, pas pour un `Workers deploy` classique.
+
+Regles a respecter :
+
+- dans le dashboard Pages, utiliser `npm run build` comme build command
+- definir `dist` comme build output directory
+- ne pas renseigner `npx wrangler deploy` comme commande de deploiement
+- pour un deploiement manuel en CLI, utiliser `npm run deploy:pages` ou `npx wrangler pages deploy dist`
+
+Symptome d une mauvaise configuration : si Cloudflare lance `wrangler deploy`, Wrangler detecte un projet Pages puis echoue en reclamant `main` ou `assets.directory`. Dans ce cas, il faut corriger la configuration du projet Pages, pas convertir ce repo en Worker classique.
 
 Pour les smoke E2E en local :
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite",
     "build": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite build",
+    "deploy:pages": "npm run build && npm exec -- wrangler pages deploy dist",
     "preview": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite preview",
     "lint": "node scripts/ensure-local-env.mjs && npm exec -- eslint . --report-unused-disable-directives --max-warnings 0",
     "typecheck": "node scripts/ensure-local-env.mjs && npm exec -- tsc --noEmit",


### PR DESCRIPTION
## Summary
- add an explicit `deploy:pages` script using `wrangler pages deploy dist`
- document that this repository must be deployed as a Cloudflare Pages project, not with `wrangler deploy`
- clarify the expected Cloudflare build and output settings to avoid the `main` / `assets.directory` deployment failure

## Validation
- `npm run build`

## Release flow
- pushed on `develop`
- fast-forwarded to `release/1.1`
- PR opened to `main` for manual review and validation
