### PR TITLE
fix(pages): supprimer observability de wrangler

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -49,7 +49,7 @@ Regles de setup :
 - definir `VITE_CF_WEB_ANALYTICS_TOKEN` dans les environnements cibles
 - ne pas activer en meme temps une injection automatique du beacon dans le dashboard pour eviter un double snippet
 - garder la CSP autorisant `https://static.cloudflareinsights.com`
-- conserver [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc) comme source de verite pour l observabilite runtime edge
+- ne pas declarer `observability` dans [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc) car Cloudflare Pages rejette ce champ au build
 
 Comportement runtime :
 
@@ -59,10 +59,8 @@ Comportement runtime :
 
 Observabilite Functions :
 
-- `observability.enabled=true`
-- logs persistants actifs
-- traces persistantes actives
-- sampling fixe a `1` tant que le volume reste raisonnable
+- pour ce projet Pages, l observabilite edge ne doit pas etre configuree dans `wrangler.jsonc`
+- si des reglages runtime edge sont necessaires, ils doivent etre geres depuis le dashboard Cloudflare compatible Pages
 
 Variables privees utiles pour l'assistance vocale :
 
@@ -101,6 +99,8 @@ Regles a respecter :
 - pour un deploiement manuel en CLI, utiliser `npm run deploy:pages` ou `npx wrangler pages deploy dist`
 
 Symptome d une mauvaise configuration : si Cloudflare lance `wrangler deploy`, Wrangler detecte un projet Pages puis echoue en reclamant `main` ou `assets.directory`. Dans ce cas, il faut corriger la configuration du projet Pages, pas convertir ce repo en Worker classique.
+
+Autre symptome connu : si Pages lit `wrangler.jsonc` et echoue sur `observability`, il faut retirer ce bloc de la config car il n est pas supporte sur les projets Pages.
 
 Pour les smoke E2E en local :
 

--- a/scripts/validate-wrangler-config.mjs
+++ b/scripts/validate-wrangler-config.mjs
@@ -11,16 +11,8 @@ if (config.pages_build_output_dir !== './dist') {
   throw new Error(`wrangler.jsonc must keep pages_build_output_dir="./dist" (current: ${config.pages_build_output_dir ?? 'missing'})`);
 }
 
-if (!config.observability?.enabled) {
-  throw new Error('wrangler.jsonc must enable observability.');
-}
-
-if (!config.observability?.logs?.enabled || !config.observability?.logs?.persist) {
-  throw new Error('wrangler.jsonc must enable persistent logs.');
-}
-
-if (!config.observability?.traces?.enabled || !config.observability?.traces?.persist) {
-  throw new Error('wrangler.jsonc must enable persistent traces.');
+if (config.observability !== undefined) {
+  throw new Error('wrangler.jsonc must not declare observability for a Cloudflare Pages project.');
 }
 
 console.log('Wrangler config validation passed');

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,21 +3,5 @@
 
   "name": "bougnat-darts-counter",
   "pages_build_output_dir": "./dist",
-  "compatibility_date": "2026-05-19",
-
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    },
-    "traces": {
-      "enabled": true,
-      "persist": true,
-      "head_sampling_rate": 1
-    }
-  }
+  "compatibility_date": "2026-05-19"
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `observability` block from `wrangler.jsonc` for Cloudflare Pages
- update the local Wrangler validation script to reject `observability` on Pages projects
- clarify the Pages limitation in the technical documentation

## Validation
- `npm run wrangler:check`
- `npm run build`

## Notes
- `public/app-qr.svg` was left out of this commit
- release branch `release/1.1` was fast-forwarded from `develop`
