### PR TITLE
fix(pages): verrouiller les variables de build

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -35,6 +35,11 @@ Variables publiques utiles :
 - `VITE_ENABLE_VOICE_SCORING`
 - `VITE_LOG_LEVEL`
 
+Pour ce projet Cloudflare Pages connecte a Wrangler :
+
+- les variables publiques `VITE_*` sont declarees dans [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc)
+- les secrets serveur restent geres comme secrets Cloudflare et ne doivent pas etre commits
+
 URLs cibles actuellement attendues :
 
 - `preprod`: `https://preprod-play.bougnatdarts.fr`
@@ -97,6 +102,7 @@ Regles a respecter :
 - definir `dist` comme build output directory
 - ne pas renseigner `npx wrangler deploy` comme commande de deploiement
 - pour un deploiement manuel en CLI, utiliser `npm run deploy:pages` ou `npx wrangler pages deploy dist`
+- si le projet affiche que les variables sont gerees par Wrangler, maintenir les `VITE_*` dans `wrangler.jsonc` plutot que dans le dashboard Pages
 
 Symptome d une mauvaise configuration : si Cloudflare lance `wrangler deploy`, Wrangler detecte un projet Pages puis echoue en reclamant `main` ou `assets.directory`. Dans ce cas, il faut corriger la configuration du projet Pages, pas convertir ce repo en Worker classique.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite",
-    "build": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite build",
+    "build": "node scripts/ensure-local-env.mjs && node scripts/validate-pages-build-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite build",
     "deploy:pages": "npm run build && npm exec -- wrangler pages deploy dist",
     "preview": "node scripts/ensure-local-env.mjs && node scripts/generate-app-qr.mjs && npm exec -- vite preview",
     "lint": "node scripts/ensure-local-env.mjs && npm exec -- eslint . --report-unused-disable-directives --max-warnings 0",

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -97,7 +97,7 @@ console.log('-------------------------------------');
 console.log(`Environment target : ${targetLabel}`);
 console.log('Environment vars   : VITE_APP_ENV, VITE_APP_NAME, VITE_APP_URL, VITE_CF_WEB_ANALYTICS_TOKEN, VITE_ENABLE_VOICE_SCORING');
 console.log('Server-only secrets: DEEPGRAM_API_KEY, DEEPGRAM_PROJECT_ID');
-console.log('Source of truth    : GitHub Environment variables and secrets, not committed env files');
+console.log('Source of truth    : Wrangler-managed public vars plus deployment secrets, not committed local env files');
 console.log('');
 
 if (warnings.length > 0) {

--- a/scripts/ensure-local-env.mjs
+++ b/scripts/ensure-local-env.mjs
@@ -4,8 +4,15 @@ import path from 'node:path';
 const rootDir = process.cwd();
 const localEnvPath = path.join(rootDir, '.env.local');
 const exampleEnvPath = path.join(rootDir, '.env.local.example');
+const isCloudflarePages = process.env.CF_PAGES === '1';
+const isCi = process.env.CI === 'true';
 
 if (fs.existsSync(localEnvPath)) {
+  process.exit(0);
+}
+
+if (isCloudflarePages || isCi) {
+  console.warn('[ensure-local-env] Skipping .env.local restore in CI/Pages. Deployment variables must come from the platform environment.');
   process.exit(0);
 }
 

--- a/scripts/validate-pages-build-env.mjs
+++ b/scripts/validate-pages-build-env.mjs
@@ -1,0 +1,56 @@
+function readValue(key) {
+  return (process.env[key] || '').trim();
+}
+
+function isHttpsUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+const isCloudflarePages = process.env.CF_PAGES === '1';
+
+if (!isCloudflarePages) {
+  process.exit(0);
+}
+
+const branch = readValue('CF_PAGES_BRANCH').toLowerCase();
+const appEnv = readValue('VITE_APP_ENV').toLowerCase();
+const appUrl = readValue('VITE_APP_URL');
+const localLikeEnvs = new Set(['', 'local', 'dev', 'development', 'ci', 'test']);
+const errors = [];
+
+if (localLikeEnvs.has(appEnv)) {
+  errors.push(`VITE_APP_ENV must be set for Cloudflare Pages and cannot be local/dev-like (current: ${appEnv || 'missing'}).`);
+}
+
+if (!appUrl) {
+  errors.push('VITE_APP_URL must be set for Cloudflare Pages builds.');
+} else if (!isHttpsUrl(appUrl)) {
+  errors.push(`VITE_APP_URL must be an https URL on Cloudflare Pages (current: ${appUrl}).`);
+} else if (/localhost|127\.0\.0\.1/.test(appUrl)) {
+  errors.push(`VITE_APP_URL cannot point to localhost on Cloudflare Pages (current: ${appUrl}).`);
+}
+
+if (branch === 'production' && appEnv !== 'production') {
+  errors.push(`CF_PAGES_BRANCH=production requires VITE_APP_ENV=production (current: ${appEnv || 'missing'}).`);
+}
+
+if (branch === 'preprod' && appEnv !== 'preprod') {
+  errors.push(`CF_PAGES_BRANCH=preprod requires VITE_APP_ENV=preprod (current: ${appEnv || 'missing'}).`);
+}
+
+if (errors.length > 0) {
+  console.error('[validate-pages-build-env] Cloudflare Pages build configuration is invalid.');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  console.error('- Declare public VITE_* variables in wrangler.jsonc when the project is Wrangler-managed.');
+  console.error('- Keep server-only secrets in Cloudflare Pages / Workers secrets.');
+  process.exit(1);
+}
+
+console.log(`[validate-pages-build-env] Cloudflare Pages variables look coherent for branch ${branch || '(unknown)'}.`);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,29 @@
 
   "name": "bougnat-darts-counter",
   "pages_build_output_dir": "./dist",
-  "compatibility_date": "2026-05-19"
+  "compatibility_date": "2026-05-19",
+
+  "vars": {
+    "DEEPGRAM_PROJECT_ID": "4ded2ce3-a84b-40fb-bfcc-473504fa041e",
+    "VITE_APP_ACCESS_MODE": "local",
+    "VITE_APP_NAME": "Bougnat Darts Counter",
+    "VITE_CF_WEB_ANALYTICS_TOKEN": "368b405964fa4515a4d54a39acb49cb5",
+    "VITE_ENABLE_VOICE_SCORING": "true",
+    "VITE_LOG_LEVEL": "warn"
+  },
+
+  "env": {
+    "production": {
+      "vars": {
+        "VITE_APP_ENV": "production",
+        "VITE_APP_URL": "https://play.bougnatdarts.fr"
+      }
+    },
+    "preview": {
+      "vars": {
+        "VITE_APP_ENV": "preprod",
+        "VITE_APP_URL": "https://preprod-play.bougnatdarts.fr"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- prevent Cloudflare Pages builds from silently falling back to local/dev values
- declare Wrangler-managed public variables for production and preview builds
- fail the Pages build early when required public variables are missing or inconsistent

## Validation
- `CF_PAGES=1 CF_PAGES_BRANCH=production node scripts/validate-pages-build-env.mjs`
- `CF_PAGES=1 CF_PAGES_BRANCH=preprod VITE_APP_ENV=preprod VITE_APP_URL=https://preprod-play.bougnatdarts.fr node scripts/validate-pages-build-env.mjs`
- `npm run build` with production Pages variables
- `npm run wrangler:check`
