### PR TITLE
fix(ci): inverser le flux preprod et production

### DIFF
--- a/.github/workflows/promote-preprod.yml
+++ b/.github/workflows/promote-preprod.yml
@@ -24,11 +24,11 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   promote:
-    name: Deploy Preview
+    name: Promote main to preprod
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: preprod
@@ -45,14 +45,14 @@ jobs:
       DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
 
     steps:
-      - name: Ensure manual run targets preprod
+      - name: Ensure manual run targets main
         run: |
-          if [ "${GITHUB_REF_NAME}" != "preprod" ]; then
-            echo "This workflow must be launched from the preprod branch." >&2
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "This workflow must be launched from the main branch." >&2
             exit 1
           fi
-          if [ "${{ inputs.confirm_branch }}" != "preprod" ]; then
-            echo "confirm_branch must equal preprod." >&2
+          if [ "${{ inputs.confirm_branch }}" != "main" ]; then
+            echo "confirm_branch must equal main." >&2
             exit 1
           fi
           if [ "${{ inputs.confirm_target }}" != "preprod" ]; then
@@ -62,6 +62,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup CI app
         uses: ./.github/actions/setup-ci-app
@@ -94,6 +96,11 @@ jobs:
       - name: Verify generated app QR asset
         run: test -s public/app-qr.svg
 
+      - name: Sync preprod mirror branch
+        run: |
+          git fetch origin preprod || true
+          git push "https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:refs/heads/preprod --force
+
       - name: Deployment summary
         run: |
           {
@@ -103,5 +110,6 @@ jobs:
             echo "- Commit: \`${GITHUB_SHA}\`"
             echo "- Reason: ${{ inputs.reason || 'n/a' }}"
             echo "- Build: \`npm run build\` validated"
-            echo "- Delivery: handled by the connected hosting project for the tracked branch"
+            echo "- Synced branch: \`preprod\`"
+            echo "- Delivery: handled by the connected hosting project for the \`preprod\` branch"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   promote:
-    name: Promote main to production
+    name: Promote preprod to production
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
@@ -45,14 +45,14 @@ jobs:
       DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
 
     steps:
-      - name: Ensure manual run targets main
+      - name: Ensure manual run targets preprod
         run: |
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "This workflow must be launched from the main branch." >&2
+          if [ "${GITHUB_REF_NAME}" != "preprod" ]; then
+            echo "This workflow must be launched from the preprod branch." >&2
             exit 1
           fi
-          if [ "${{ inputs.confirm_branch }}" != "main" ]; then
-            echo "confirm_branch must equal main." >&2
+          if [ "${{ inputs.confirm_branch }}" != "preprod" ]; then
+            echo "confirm_branch must equal preprod." >&2
             exit 1
           fi
           if [ "${{ inputs.confirm_target }}" != "production" ]; then

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -138,25 +138,25 @@ La qualite du projet repose aussi sur :
 
 Flux de branches :
 
-- `preprod` : branche de preview, deploiement manuel via `Deploy Preview`
-- `main` : branche source de promotion production
+- `main` : branche source de promotion preprod
+- `preprod` : branche miroir poussee par le workflow de preprod, puis source de promotion production
 - `production` : branche miroir poussee par le workflow de promotion
 
 Workflows principaux :
 
 - `Quality Gate` : PR vers `main`, `preprod`, `develop`, `release/**`
 - `End-to-End` : PR vers `main`, `preprod`, `release/**`
-- `Deploy Preview` : manuel uniquement depuis `preprod`
-- `Promote Production` : manuel uniquement depuis `main`
+- `Deploy Preview` : manuel uniquement depuis `main`, puis synchronise la branche `preprod`
+- `Promote Production` : manuel uniquement depuis `preprod`, puis synchronise la branche `production`
 - `Validate Environments` : manuel, valide seulement le contrat d environnement cible
 
 Regles de securite recommandees dans GitHub :
 
-- environment `preprod` : limiter les deploiements a la branche `preprod`
-- environment `production` : limiter les deploiements a la branche `main`
+- environment `preprod` : limiter les lancements manuels a la branche `main`
+- environment `production` : limiter les lancements manuels a la branche `preprod`
 - environment `production` : exiger au moins un reviewer manuel avant execution
 - conserver les secrets uniquement au niveau des environments qui les utilisent
-- le workflow `Promote Production` peut pousser la branche miroir `production` avec le `GITHUB_TOKEN`, sans GitHub App dediee
+- les workflows `Deploy Preview` et `Promote Production` peuvent pousser les branches miroirs `preprod` et `production` avec le `GITHUB_TOKEN`, sans GitHub App dediee
 
 ## Documentation technique
 


### PR DESCRIPTION
## Summary
- require preprod promotion to be launched from `main`
- require production promotion to be launched from `preprod`
- sync the `preprod` and `production` mirror branches from those manual workflows
- align the branch-governance documentation with the new flow

## Validation
- editor diagnostics on the touched workflow files
- `git diff --check` on the touched workflow and documentation files
