### PR TITLE
fix(security): retirer le token analytics du repo

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+78b6a16e5d2b0b91088a78b6bd3aa4fa42f7e572:wrangler.jsonc:generic-api-key:16
+78b6a16e5d2b0b91088a78b6bd3aa4fa42f7e572:wrangler.jsonc:generic-api-key:28

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -38,6 +38,7 @@ Variables publiques utiles :
 Pour ce projet Cloudflare Pages connecte a Wrangler :
 
 - les variables publiques `VITE_*` sont declarees dans [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc)
+- les blocs `env.production.vars` et `env.preview.vars` doivent etre complets, car Wrangler n herite pas les `vars` top-level vers les environnements
 - les secrets serveur restent geres comme secrets Cloudflare et ne doivent pas etre commits
 
 URLs cibles actuellement attendues :

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -37,7 +37,8 @@ Variables publiques utiles :
 
 Pour ce projet Cloudflare Pages connecte a Wrangler :
 
-- les variables publiques `VITE_*` sont declarees dans [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc)
+- les variables publiques de routage `VITE_APP_*`, `VITE_ENABLE_VOICE_SCORING`, `VITE_LOG_LEVEL` et `DEEPGRAM_PROJECT_ID` sont declarees dans [wrangler.jsonc](/home/e103350/projects/perso/Bougnat_darts_counter/wrangler.jsonc)
+- `VITE_CF_WEB_ANALYTICS_TOKEN` doit etre injecte par les variables de build Cloudflare Pages ou par un secret Cloudflare, pas commit dans le repo
 - les blocs `env.production.vars` et `env.preview.vars` doivent etre complets, car Wrangler n herite pas les `vars` top-level vers les environnements
 - les secrets serveur restent geres comme secrets Cloudflare et ne doivent pas etre commits
 
@@ -103,7 +104,7 @@ Regles a respecter :
 - definir `dist` comme build output directory
 - ne pas renseigner `npx wrangler deploy` comme commande de deploiement
 - pour un deploiement manuel en CLI, utiliser `npm run deploy:pages` ou `npx wrangler pages deploy dist`
-- si le projet affiche que les variables sont gerees par Wrangler, maintenir les `VITE_*` dans `wrangler.jsonc` plutot que dans le dashboard Pages
+- si le projet affiche que les variables sont gerees par Wrangler, maintenir les variables de routage dans `wrangler.jsonc` et injecter `VITE_CF_WEB_ANALYTICS_TOKEN` depuis les variables de build Pages
 
 Symptome d une mauvaise configuration : si Cloudflare lance `wrangler deploy`, Wrangler detecte un projet Pages puis echoue en reclamant `main` ou `assets.directory`. Dans ce cas, il faut corriger la configuration du projet Pages, pas convertir ce repo en Worker classique.
 

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -97,7 +97,7 @@ console.log('-------------------------------------');
 console.log(`Environment target : ${targetLabel}`);
 console.log('Environment vars   : VITE_APP_ENV, VITE_APP_NAME, VITE_APP_URL, VITE_CF_WEB_ANALYTICS_TOKEN, VITE_ENABLE_VOICE_SCORING');
 console.log('Server-only secrets: DEEPGRAM_API_KEY, DEEPGRAM_PROJECT_ID');
-console.log('Source of truth    : Wrangler-managed public vars plus deployment secrets, not committed local env files');
+console.log('Source of truth    : Wrangler-managed routing vars plus deployment-provided analytics and secrets, not committed local env files');
 console.log('');
 
 if (warnings.length > 0) {

--- a/scripts/validate-pages-build-env.mjs
+++ b/scripts/validate-pages-build-env.mjs
@@ -20,6 +20,7 @@ if (!isCloudflarePages) {
 const branch = readValue('CF_PAGES_BRANCH').toLowerCase();
 const appEnv = readValue('VITE_APP_ENV').toLowerCase();
 const appUrl = readValue('VITE_APP_URL');
+const analyticsToken = readValue('VITE_CF_WEB_ANALYTICS_TOKEN');
 const localLikeEnvs = new Set(['', 'local', 'dev', 'development', 'ci', 'test']);
 const errors = [];
 
@@ -35,6 +36,10 @@ if (!appUrl) {
   errors.push(`VITE_APP_URL cannot point to localhost on Cloudflare Pages (current: ${appUrl}).`);
 }
 
+if (!analyticsToken) {
+  errors.push('VITE_CF_WEB_ANALYTICS_TOKEN must be set for Cloudflare Pages builds.');
+}
+
 if (branch === 'production' && appEnv !== 'production') {
   errors.push(`CF_PAGES_BRANCH=production requires VITE_APP_ENV=production (current: ${appEnv || 'missing'}).`);
 }
@@ -48,7 +53,8 @@ if (errors.length > 0) {
   for (const error of errors) {
     console.error(`- ${error}`);
   }
-  console.error('- Declare public VITE_* variables in wrangler.jsonc when the project is Wrangler-managed.');
+  console.error('- Declare routing/public VITE_* variables in wrangler.jsonc when the project is Wrangler-managed.');
+  console.error('- Provide VITE_CF_WEB_ANALYTICS_TOKEN from Cloudflare Pages build variables or secrets instead of committing it.');
   console.error('- Keep server-only secrets in Cloudflare Pages / Workers secrets.');
   process.exit(1);
 }

--- a/scripts/validate-wrangler-config.mjs
+++ b/scripts/validate-wrangler-config.mjs
@@ -12,7 +12,6 @@ const requiredPagesVars = [
   'VITE_APP_ENV',
   'VITE_APP_NAME',
   'VITE_APP_URL',
-  'VITE_CF_WEB_ANALYTICS_TOKEN',
   'VITE_ENABLE_VOICE_SCORING',
   'VITE_LOG_LEVEL',
 ];

--- a/scripts/validate-wrangler-config.mjs
+++ b/scripts/validate-wrangler-config.mjs
@@ -6,6 +6,16 @@ const raw = fs.readFileSync(configPath, 'utf8');
 
 // The project intentionally keeps wrangler.jsonc comment-free so JSON.parse is enough here.
 const config = JSON.parse(raw);
+const requiredPagesVars = [
+  'DEEPGRAM_PROJECT_ID',
+  'VITE_APP_ACCESS_MODE',
+  'VITE_APP_ENV',
+  'VITE_APP_NAME',
+  'VITE_APP_URL',
+  'VITE_CF_WEB_ANALYTICS_TOKEN',
+  'VITE_ENABLE_VOICE_SCORING',
+  'VITE_LOG_LEVEL',
+];
 
 if (config.pages_build_output_dir !== './dist') {
   throw new Error(`wrangler.jsonc must keep pages_build_output_dir="./dist" (current: ${config.pages_build_output_dir ?? 'missing'})`);
@@ -13,6 +23,22 @@ if (config.pages_build_output_dir !== './dist') {
 
 if (config.observability !== undefined) {
   throw new Error('wrangler.jsonc must not declare observability for a Cloudflare Pages project.');
+}
+
+if (config.vars !== undefined) {
+  throw new Error('wrangler.jsonc must not rely on top-level vars for Pages environments because Wrangler does not inherit them into env.production/env.preview.');
+}
+
+for (const environmentName of ['production', 'preview']) {
+  const vars = config.env?.[environmentName]?.vars;
+  if (!vars) {
+    throw new Error(`wrangler.jsonc must define env.${environmentName}.vars for the Cloudflare Pages project.`);
+  }
+
+  const missingVars = requiredPagesVars.filter((key) => !(key in vars));
+  if (missingVars.length > 0) {
+    throw new Error(`wrangler.jsonc env.${environmentName}.vars is missing required keys: ${missingVars.join(', ')}`);
+  }
 }
 
 console.log('Wrangler config validation passed');

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,26 +5,29 @@
   "pages_build_output_dir": "./dist",
   "compatibility_date": "2026-05-19",
 
-  "vars": {
-    "DEEPGRAM_PROJECT_ID": "4ded2ce3-a84b-40fb-bfcc-473504fa041e",
-    "VITE_APP_ACCESS_MODE": "local",
-    "VITE_APP_NAME": "Bougnat Darts Counter",
-    "VITE_CF_WEB_ANALYTICS_TOKEN": "368b405964fa4515a4d54a39acb49cb5",
-    "VITE_ENABLE_VOICE_SCORING": "true",
-    "VITE_LOG_LEVEL": "warn"
-  },
-
   "env": {
     "production": {
       "vars": {
+        "DEEPGRAM_PROJECT_ID": "4ded2ce3-a84b-40fb-bfcc-473504fa041e",
+        "VITE_APP_ACCESS_MODE": "local",
         "VITE_APP_ENV": "production",
-        "VITE_APP_URL": "https://play.bougnatdarts.fr"
+        "VITE_APP_NAME": "Bougnat Darts Counter",
+        "VITE_APP_URL": "https://play.bougnatdarts.fr",
+        "VITE_CF_WEB_ANALYTICS_TOKEN": "368b405964fa4515a4d54a39acb49cb5",
+        "VITE_ENABLE_VOICE_SCORING": "true",
+        "VITE_LOG_LEVEL": "warn"
       }
     },
     "preview": {
       "vars": {
+        "DEEPGRAM_PROJECT_ID": "4ded2ce3-a84b-40fb-bfcc-473504fa041e",
+        "VITE_APP_ACCESS_MODE": "local",
         "VITE_APP_ENV": "preprod",
-        "VITE_APP_URL": "https://preprod-play.bougnatdarts.fr"
+        "VITE_APP_NAME": "Bougnat Darts Counter",
+        "VITE_APP_URL": "https://preprod-play.bougnatdarts.fr",
+        "VITE_CF_WEB_ANALYTICS_TOKEN": "bf185e3a475f4e3b9ec84bc0fe108dff",
+        "VITE_ENABLE_VOICE_SCORING": "true",
+        "VITE_LOG_LEVEL": "warn"
       }
     }
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,6 @@
         "VITE_APP_ENV": "production",
         "VITE_APP_NAME": "Bougnat Darts Counter",
         "VITE_APP_URL": "https://play.bougnatdarts.fr",
-        "VITE_CF_WEB_ANALYTICS_TOKEN": "368b405964fa4515a4d54a39acb49cb5",
         "VITE_ENABLE_VOICE_SCORING": "true",
         "VITE_LOG_LEVEL": "warn"
       }
@@ -25,7 +24,6 @@
         "VITE_APP_ENV": "preprod",
         "VITE_APP_NAME": "Bougnat Darts Counter",
         "VITE_APP_URL": "https://preprod-play.bougnatdarts.fr",
-        "VITE_CF_WEB_ANALYTICS_TOKEN": "bf185e3a475f4e3b9ec84bc0fe108dff",
         "VITE_ENABLE_VOICE_SCORING": "true",
         "VITE_LOG_LEVEL": "warn"
       }


### PR DESCRIPTION
## Summary
- remove committed Cloudflare Web Analytics tokens from wrangler.jsonc
- require VITE_CF_WEB_ANALYTICS_TOKEN at Cloudflare Pages build time instead of versioning it
- keep a narrowly scoped gitleaks ignore for the already published historical fingerprints

## Validation
- npm run wrangler:check
- CF_PAGES=1 CF_PAGES_BRANCH=production VITE_APP_ENV=production VITE_APP_URL=https://play.bougnatdarts.fr VITE_CF_WEB_ANALYTICS_TOKEN=provided-at-build node scripts/validate-pages-build-env.mjs