### PR TITLE
fix(mobile): ajuster le layout navigateur du 501

### DIFF
--- a/components/game/PlayerScore.tsx
+++ b/components/game/PlayerScore.tsx
@@ -7,6 +7,7 @@ interface PlayerScoreProps {
   showMatchStarterBadge?: boolean;
   currentThrowerName?: string;
   score: number;
+  compactMobileBrowser?: boolean;
   isActive: boolean;
   legsWon: number;
   setsWon?: number;
@@ -18,7 +19,18 @@ interface PlayerScoreProps {
   };
 }
 
-export const PlayerScore: React.FC<PlayerScoreProps> = ({ name, subtitle, showMatchStarterBadge, currentThrowerName, score, isActive, legsWon, setsWon, stats }) => {
+export const PlayerScore: React.FC<PlayerScoreProps> = ({
+  name,
+  subtitle,
+  showMatchStarterBadge,
+  currentThrowerName,
+  score,
+  compactMobileBrowser = false,
+  isActive,
+  legsWon,
+  setsWon,
+  stats,
+}) => {
   const normalizedName = name.trim();
   const nameWrapperRef = React.useRef<HTMLDivElement | null>(null);
   const [nameFontSizePx, setNameFontSizePx] = React.useState(32);
@@ -49,7 +61,8 @@ export const PlayerScore: React.FC<PlayerScoreProps> = ({ name, subtitle, showMa
   return (
     <div 
       className={`
-        laptop-compact-player-score relative flex h-full min-h-0 w-full min-w-0 flex-col items-center justify-between overflow-hidden pb-1 pt-16 transition-colors duration-300 sm:pt-20 md:pt-24 md:pb-4 xl:pb-8
+        laptop-compact-player-score relative flex h-full min-h-0 w-full min-w-0 flex-col items-center justify-between overflow-hidden transition-colors duration-300
+        ${compactMobileBrowser ? 'pb-1 pt-16 sm:pt-20' : 'pb-1 pt-16 sm:pt-20'} md:pt-24 md:pb-4 xl:pb-8
         ${isActive 
             ? 'bg-gray-800 text-white' 
             : 'bg-transparent text-gray-500'}
@@ -61,8 +74,8 @@ export const PlayerScore: React.FC<PlayerScoreProps> = ({ name, subtitle, showMa
       )}
 
       {/* Name block: px instead of rem so system font-scale cannot inflate this fixed footprint. */}
-      <div className="z-10 flex h-[88px] w-full shrink-0 flex-col items-center px-1 pt-2 text-center sm:px-2 md:h-[96px] xl:h-[104px]">
-          <div className="relative flex h-[44px] w-full items-center justify-center md:h-[48px] xl:h-[52px]">
+          <div className="z-10 flex h-[88px] w-full shrink-0 flex-col items-center px-1 pt-2 text-center sm:px-2 md:h-[96px] xl:h-[104px]">
+            <div className="relative flex h-[44px] w-full items-center justify-center md:h-[48px] xl:h-[52px]">
               <div ref={nameWrapperRef} className={`w-full overflow-hidden px-1 text-center ${showMatchStarterBadge ? 'pr-8' : ''}`}>
                 <div
                   className={`inline-block whitespace-nowrap font-black uppercase leading-none tracking-[0.04em] ${isActive ? 'text-orange-500' : 'text-gray-600'}`}
@@ -98,10 +111,10 @@ export const PlayerScore: React.FC<PlayerScoreProps> = ({ name, subtitle, showMa
 
       {/* Spec: spec:counter/score-layout-font-scale-resilience */}
       {/* Score font uses pure viewport units (vw+svh) — no rem — so system font-scale cannot cause overflow. */}
-      <div className="flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden pb-1 sm:pb-2 md:pb-0">
+        <div className={`flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden sm:pb-2 md:pb-0 ${compactMobileBrowser ? 'pb-1' : 'pb-1'}`}>
         <div className={`
             legacy-player-score-value laptop-compact-player-score-value z-10 font-mono font-black leading-none tracking-tighter transition-all duration-300
-            text-[min(30vw,22svh)] md:text-[clamp(5.25rem,min(14vw,15vh),11.75rem)] lg:text-[clamp(5.75rem,min(15vw,16vh),12.75rem)] xl:text-[clamp(7rem,19vw,16.5rem)]
+          ${compactMobileBrowser ? 'text-[min(27vw,19svh)] sm:text-[min(30vw,22svh)]' : 'text-[min(30vw,22svh)]'} md:text-[clamp(5.25rem,min(14vw,15vh),11.75rem)] lg:text-[clamp(5.75rem,min(15vw,16vh),12.75rem)] xl:text-[clamp(7rem,19vw,16.5rem)]
             ${isActive ? 'text-white drop-shadow-[0_0_10px_rgba(0,0,0,0.8)]' : 'text-gray-700'}
         `}>
             {score}

--- a/views/MatchView.tsx
+++ b/views/MatchView.tsx
@@ -102,6 +102,7 @@ export const MatchView: React.FC<MatchViewProps> = ({
   const [pendingCheckoutScore, setPendingCheckoutScore] = useState<number | null>(null);
   const [feedbackMessage, setFeedbackMessage] = useState<{ text: string; type: FeedbackKind } | null>(null);
   const [remainingPreview, setRemainingPreview] = useState<RemainingPreview | null>(null);
+  const [isCompactBrowserMobile, setIsCompactBrowserMobile] = useState(false);
 
   // Match UI state
   const [showHints, setShowHints] = useState(false);
@@ -232,6 +233,37 @@ export const MatchView: React.FC<MatchViewProps> = ({
     if (botVictoryPreviewTimeoutRef.current !== null) {
       window.clearTimeout(botVictoryPreviewTimeoutRef.current);
     }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    const browserMobileQuery = window.matchMedia('(max-width: 767px)');
+    const standaloneQuery = window.matchMedia('(display-mode: standalone)');
+
+    const computeCompactBrowserMobile = () => {
+      const navigatorWithStandalone = window.navigator as Navigator & { standalone?: boolean };
+      const isStandalone = standaloneQuery.matches || Boolean(navigatorWithStandalone.standalone);
+      setIsCompactBrowserMobile(browserMobileQuery.matches && !isStandalone);
+    };
+
+    computeCompactBrowserMobile();
+
+    if (typeof browserMobileQuery.addEventListener === 'function') {
+      browserMobileQuery.addEventListener('change', computeCompactBrowserMobile);
+      standaloneQuery.addEventListener('change', computeCompactBrowserMobile);
+      return () => {
+        browserMobileQuery.removeEventListener('change', computeCompactBrowserMobile);
+        standaloneQuery.removeEventListener('change', computeCompactBrowserMobile);
+      };
+    }
+
+    browserMobileQuery.addListener(computeCompactBrowserMobile);
+    standaloneQuery.addListener(computeCompactBrowserMobile);
+    return () => {
+      browserMobileQuery.removeListener(computeCompactBrowserMobile);
+      standaloneQuery.removeListener(computeCompactBrowserMobile);
+    };
   }, []);
 
   const triggerFeedback = (text: string, type: 'bust' | 'miss' | 'info' | 'notice') => {
@@ -692,7 +724,7 @@ export const MatchView: React.FC<MatchViewProps> = ({
       {/* Control Area */}
       {/* Spec: spec:counter/score-layout-font-scale-resilience */}
       {/* Control area uses px instead of rem for floor/ceil so system font-scale cannot push the keypad off screen. */}
-      <div className="legacy-match-control-area laptop-compact-control-area relative z-30 flex h-[clamp(220px,38svh,380px)] shrink-0 flex-col border-t border-gray-800 bg-gray-900 pb-safe shadow-[0_-5px_20px_rgba(0,0,0,0.5)] sm:h-[clamp(240px,39svh,400px)] md:h-[clamp(16rem,32svh,24rem)] xl:h-[clamp(20rem,37svh,29rem)]">
+      <div className={`legacy-match-control-area laptop-compact-control-area relative z-30 flex shrink-0 flex-col border-t border-gray-800 bg-gray-900 pb-safe shadow-[0_-5px_20px_rgba(0,0,0,0.5)] sm:h-[clamp(240px,39svh,400px)] md:h-[clamp(16rem,32svh,24rem)] xl:h-[clamp(20rem,37svh,29rem)] ${isCompactBrowserMobile ? 'h-[clamp(196px,33svh,320px)]' : 'h-[clamp(220px,38svh,380px)]'}`}>
          
          <MatchInputBar
            canUndo={canUndoAction}
@@ -845,6 +877,7 @@ export const MatchView: React.FC<MatchViewProps> = ({
             name={playerScore.name}
             subtitle={playerScore.subtitle}
             showMatchStarterBadge={playerScore.showMatchStarterBadge}
+          compactMobileBrowser={isCompactBrowserMobile}
             isActive={playerScore.isActive}
             score={playerScore.score}
             legsWon={playerScore.legsWon}


### PR DESCRIPTION
## Summary
- apply a compact layout only for smartphone browsers running the 501 screen outside standalone mode
- preserve the installed app layout while freeing vertical space in the browser case
- keep player names clear of the legs pill while preventing score clipping

## Validation
- npm run build
- smartphone browser viewport check on the local 501 match screen
