### PR TITLE
fix(preprod): patch CSP and update preview URL

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -44,7 +44,7 @@ Pour ce projet Cloudflare Pages connecte a Wrangler :
 
 URLs cibles actuellement attendues :
 
-- `preprod`: `https://preprod-play.bougnatdarts.fr`
+- `preprod`: `https://ccdc74ab.bougnat-darts-counter.pages.dev`
 - `production`: `https://play.bougnatdarts.fr`
 
 ## Observabilite web

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.deepgram.com wss://api.deepgram.com https://cloudflareinsights.com; frame-src 'none'; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' data: https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.deepgram.com wss://api.deepgram.com https://cloudflareinsights.com; frame-src 'none'; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,7 +23,7 @@
         "VITE_APP_ACCESS_MODE": "local",
         "VITE_APP_ENV": "preprod",
         "VITE_APP_NAME": "Bougnat Darts Counter",
-        "VITE_APP_URL": "https://preprod-play.bougnatdarts.fr",
+        "VITE_APP_URL": "https://ccdc74ab.bougnat-darts-counter.pages.dev",
         "VITE_ENABLE_VOICE_SCORING": "true",
         "VITE_LOG_LEVEL": "warn"
       }


### PR DESCRIPTION
## Context
Follow-up after merged release PR #151 to address preprod runtime startup on the Pages URL.

## Changes
- Patch CSP in public/_headers to allow required runtime script execution for current Vite output.
- Update preprod preview URL to https://ccdc74ab.bougnat-darts-counter.pages.dev in wrangler preview vars.
- Align technical documentation preprod URL.

## Validation
- npm run build

## Notes
- public/app-qr.svg regeneration was intentionally excluded from this commit.
